### PR TITLE
docs: add 650 industries aka expo as license holder

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,7 @@
 # The MIT License (MIT)
 
 Copyright (c) 2019 Cedric van Putten <me@bycedric.com>
+Copyright (c) 2019-present 650 Industries, Inc. (aka Expo)
 
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
### Linked issue
This should be there too.
