### PR TITLE
Feat/docker image from ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+---
+language: bash
+services:
+  - docker
+env:
+  global:
+    - DOCKER_IMAGE=bycedric/expo-cli
+    - DOCKER_TAG=2
+script:
+  - docker build base -t $DOCKER_IMAGE:$DOCKER_TAG
+  - docker run -ti --rm $DOCKER_IMAGE:$DOCKER_TAG diagnostics
+before_deploy:
+  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+  - docker tag $DOCKER_IMAGE:$DOCKER_TAG $DOCKER_IMAGE:latest
+deploy:
+  provider: script
+  script: docker push $DOCKER_IMAGE:$DOCKER_TAG && docker push $DOCKER_IMAGE:latest
+  on:
+    branch: master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bycedric/ci-expo:2
+FROM bycedric/expo-cli:2
 
 LABEL com.github.actions.name="Expo CLI"
 LABEL com.github.actions.description="Use any Expo CLI command in your GitHub Actions workflow."

--- a/base/README.md
+++ b/base/README.md
@@ -1,5 +1,7 @@
 # Expo for Docker
 
+[![Build Status](https://travis-ci.com/expo/expo-github-action.svg?branch=master)](https://travis-ci.com/expo/expo-github-action)
+
 A prebuilt docker image to use the [Expo CLI][link-expo-cli] on Docker-based environments.
 This image contains all necessary libraries to perform all commands of the CLI.
 


### PR DESCRIPTION
### Linked issue
Fixes #4.

### Additional context
To get this merged, I think we need to briefly check the following questions:

1. Is it ok to keep the docker image under my account, or do you want to have it under an Expo account/organization?
2. Do we need to update the [maintainer info from the base image](https://github.com/expo/expo-github-action/blob/master/base/Dockerfile#L6)?
