### PR TITLE
Fix/node memory limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ env:
 script:
   - docker build base -t $DOCKER_IMAGE:$DOCKER_TAG
   - docker run -ti --rm $DOCKER_IMAGE:$DOCKER_TAG diagnostics
+  - docker build . -t expo/expo-github-action
+  - docker run -ti --rm expo/expo-github-action diagnostics
 before_deploy:
   - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
   - docker tag $DOCKER_IMAGE:$DOCKER_TAG $DOCKER_IMAGE:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,8 @@ LABEL com.github.actions.color="gray-dark"
 
 COPY entrypoint.sh LICENSE.md README.md /
 
+# increase node's default memory limit to 4gb
+# see: https://github.com/expo/expo-github-action/#overwriting-node_options
+ENV NODE_OPTIONS="--max_old_space_size=4096"
+
 entrypoint ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ variable            | description
 > Some Expo commands don't require authentication.
 > Simply omit the `secrets = [...]` if you don't need it.
 
+### Some caveats
+
+#### Overwriting `NODE_OPTIONS`
+
+By default, Node has a "limited" memory limit.
+To fully use the available memory in GitHub Actions, the `NODE_OPTIONS` variable is set to `--max_old_space_size=4096`.
+If you need to overwrite this variable, make sure you add this value too or risk Node running out of memory.
+See [issue #12][link-issue-memory] for more info.
+
 ## Example workflows
 
 Before you dive into the workflow examples, you should know the basics of GitHub Actions.
@@ -154,3 +163,4 @@ The MIT License (MIT). Please see [License File](LICENSE.md) for more informatio
 [link-expo]: https://expo.io
 [link-expo-cli]: https://docs.expo.io/versions/latest/workflow/expo-cli
 [link-expo-cli-password]: https://github.com/expo/expo-cli/blob/8ea616d8848a123270b97e226e33dcb3dde49653/packages/expo-cli/src/accounts.js#L94
+[link-issue-memory]: https://github.com/expo/expo-github-action/issues/12


### PR DESCRIPTION
### Linked issue
Fixes #12 

### Additional context
I tested the action image using [this repository](https://github.com/Data-Wrangling-with-JavaScript/nodejs-memory-test). Before the fix it was breaking on 1.35GB, after the fix, it's still going strong after 2.75GB. I also added a double check in Travis to make sure we are staging valid docker images as action.
