### PR TITLE
fix: use yarn to install expo cli globally

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -5,9 +5,8 @@ LABEL repository="https://github.com/expo/expo-github-action"
 LABEL homepage="https://github.com/expo/expo-github-action/blob/master/base"
 LABEL maintainer="Cedric van Putten <me+expo-action@bycedric.com>"
 
-RUN npm install --global expo-cli@2 \
-	&& npm cache rm --force \
-	&& rm -rf ~/.npm
+RUN yarn global add expo-cli@2 \
+	&& yarn cache clean
 
 COPY entrypoint.sh LICENSE.md README.md /
 


### PR DESCRIPTION
### Linked issue
This is related to NPM failing for both iltorb and sharp dependencies. Let's work around this by using Yarn for now.

### Additional context
https://github.com/expo/expo-cli/issues/591
