### PR TITLE
refactor!: use yarn by default instead of npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ variable              | description
 `expo-username`       | The username of your Expo account. _(you can hardcode this or use secrets)_
 `expo-password`       | The password of your Expo account. _**([use this with secrets][link-actions-secrets])**_
 `expo-version`        | The Expo CLI you want to use. _(can be any semver range, defaults to `latest`)_
-`expo-packager`       | The package manager you want to use to install the CLI. _(can be `npm` or `yarn`, defaults to `npm`)_
+`expo-packager`       | The package manager you want to use to install the CLI. _(can be `npm` or `yarn`, defaults to `yarn`)_
 `expo-patch-watchers` | If it should patch the `fs.inotify.` limits causing `ENOSPC` errors on Linux. _(can be `true` or `false`, defaults to `true`)_
 
 > It's recommended to set the `expo-version` to avoid breaking changes when a new major version is released.

--- a/build/index.js
+++ b/build/index.js
@@ -29589,7 +29589,7 @@ const install_1 = __webpack_require__(655);
 const system_1 = __webpack_require__(913);
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
-        const path = yield install_1.install(core_1.getInput('expo-version') || 'latest', core_1.getInput('expo-packager') || 'npm');
+        const path = yield install_1.install(core_1.getInput('expo-version') || 'latest', core_1.getInput('expo-packager') || 'yarn');
         core_1.addPath(path);
         yield expo_1.authenticate(core_1.getInput('expo-username'), core_1.getInput('expo-password'));
         const shouldPatchWatchers = core_1.getInput('expo-patch-watchers') || 'true';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { patchWatchers } from './system';
 export async function run() {
 	const path = await install(
 		getInput('expo-version') || 'latest',
-		getInput('expo-packager') || 'npm',
+		getInput('expo-packager') || 'yarn',
 	);
 
 	addPath(path);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -38,15 +38,15 @@ const mockInput = (props: MockInputProps = {}) => {
 };
 
 describe('run', () => {
-	test('installs latest expo-cli with npm by default', async () => {
+	test('installs latest expo-cli with yarn by default', async () => {
 		await run();
-		expect(install.install).toBeCalledWith('latest', 'npm');
+		expect(install.install).toBeCalledWith('latest', 'yarn');
 	});
 
-	test('installs provided version expo-cli with yarn', async () => {
-		mockInput({ version: '3.0.10', packager: 'yarn' });
+	test('installs provided version expo-cli with npm', async () => {
+		mockInput({ version: '3.0.10', packager: 'npm' });
 		await run();
-		expect(install.install).toBeCalledWith('3.0.10', 'yarn');
+		expect(install.install).toBeCalledWith('3.0.10', 'npm');
 	});
 
 	test('installs path to global path', async () => {


### PR DESCRIPTION
### Linked issue
Expo recommends using yarn, so let's use that by default.
