### PR TITLE
fix: remove custom and add global error handling

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -20413,15 +20413,9 @@ function authenticate(username, password) {
         const bin = process.platform === 'win32'
             ? 'expo.cmd'
             : 'expo';
-        try {
-            yield cli.exec(bin, ['login', `--username=${username}`], {
-                env: Object.assign(Object.assign({}, process.env), { EXPO_CLI_PASSWORD: password }),
-            });
-        }
-        catch (error) {
-            core.setFailed(error);
-            throw error;
-        }
+        yield cli.exec(bin, ['login', `--username=${username}`], {
+            env: Object.assign(Object.assign({}, process.env), { EXPO_CLI_PASSWORD: password }),
+        });
     });
 }
 exports.authenticate = authenticate;
@@ -25945,9 +25939,17 @@ Promise._SomePromiseArray = SomePromiseArray;
 
 "use strict";
 
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
 Object.defineProperty(exports, "__esModule", { value: true });
+const core = __importStar(__webpack_require__(470));
 const run_1 = __webpack_require__(180);
-run_1.run();
+run_1.run().catch(core.setFailed);
 
 
 /***/ }),
@@ -54205,7 +54207,6 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const lib_1 = __webpack_require__(484);
-const core = __importStar(__webpack_require__(470));
 const toolCache = __importStar(__webpack_require__(533));
 const path_1 = __importDefault(__webpack_require__(622));
 const os_1 = __importDefault(__webpack_require__(87));
@@ -54242,15 +54243,9 @@ function fromRemoteCache(version, packager, customCacheKey) {
         // see: https://github.com/actions/toolkit/blob/8a4134761f09d0d97fb15f297705fd8644fef920/packages/tool-cache/src/tool-cache.ts#L401
         const target = path_1.default.join(process.env['RUNNER_TOOL_CACHE'] || '', 'expo-cli', version, os_1.default.arch());
         const cacheKey = customCacheKey || getRemoteKey(version, packager);
-        try {
-            const hit = yield lib_1.restoreCache(target, cacheKey, cacheKey);
-            if (hit) {
-                return target;
-            }
-        }
-        catch (error) {
-            core.setFailed(error);
-            throw error;
+        const hit = yield lib_1.restoreCache(target, cacheKey, cacheKey);
+        if (hit) {
+            return target;
         }
     });
 }
@@ -54262,13 +54257,7 @@ exports.fromRemoteCache = fromRemoteCache;
 function toRemoteCache(source, version, packager, customCacheKey) {
     return __awaiter(this, void 0, void 0, function* () {
         const cacheKey = customCacheKey || getRemoteKey(version, packager);
-        try {
-            yield lib_1.saveCache(source, cacheKey);
-        }
-        catch (error) {
-            core.setFailed(error);
-            throw error;
-        }
+        yield lib_1.saveCache(source, cacheKey);
     });
 }
 exports.toRemoteCache = toRemoteCache;

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,5 +1,4 @@
 import { restoreCache, saveCache } from '@actions/cache/lib';
-import * as core from '@actions/core';
 import * as toolCache from '@actions/tool-cache';
 import path from 'path';
 import os from 'os';
@@ -32,16 +31,10 @@ export async function fromRemoteCache(version: string, packager: string, customC
 	// see: https://github.com/actions/toolkit/blob/8a4134761f09d0d97fb15f297705fd8644fef920/packages/tool-cache/src/tool-cache.ts#L401
 	const target = path.join(process.env['RUNNER_TOOL_CACHE'] || '', 'expo-cli', version, os.arch());
 	const cacheKey = customCacheKey || getRemoteKey(version, packager);
+	const hit = await restoreCache(target, cacheKey, cacheKey);
 
-	try {
-		const hit = await restoreCache(target, cacheKey, cacheKey);
-
-		if (hit) {
-			return target;
-		}
-	} catch (error) {
-		core.setFailed(error);
-		throw error;
+	if (hit) {
+		return target;
 	}
 }
 
@@ -52,12 +45,7 @@ export async function fromRemoteCache(version: string, packager: string, customC
 export async function toRemoteCache(source: string, version: string, packager: string, customCacheKey?: string) {
 	const cacheKey = customCacheKey || getRemoteKey(version, packager);
 
-	try {
-		await saveCache(source, cacheKey);
-	} catch (error) {
-		core.setFailed(error);
-		throw error;
-	}
+	await saveCache(source, cacheKey);
 }
 
 /**

--- a/src/expo.ts
+++ b/src/expo.ts
@@ -16,15 +16,10 @@ export async function authenticate(username: string, password: string) {
 		? 'expo.cmd'
 		: 'expo';
 
-	try {
-		await cli.exec(bin, ['login', `--username=${username}`], {
-			env: {
-				...process.env,
-				EXPO_CLI_PASSWORD: password,
-			},
-		});
-	} catch (error) {
-		core.setFailed(error);
-		throw error;
-	}
+	await cli.exec(bin, ['login', `--username=${username}`], {
+		env: {
+			...process.env,
+			EXPO_CLI_PASSWORD: password,
+		},
+	});
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import * as core from '@actions/core';
 import { run } from './run';
 
-run();
+run().catch(core.setFailed);

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -1,5 +1,4 @@
 import * as remoteCache from '@actions/cache/lib';
-import * as core from '@actions/core';
 import * as toolCache from '@actions/tool-cache';
 import os from 'os';
 import * as cache from '../src/cache';
@@ -29,7 +28,6 @@ describe('toLocalCache', () => {
 
 describe('fromRemoteCache', () => {
 	const spy = {
-		fail: jest.spyOn(core, 'setFailed').mockImplementation(),
 		restore: jest.spyOn(remoteCache, 'restoreCache').mockImplementation(),
 	};
 
@@ -70,13 +68,11 @@ describe('fromRemoteCache', () => {
 		const error = new Error('Remote cache restore failed');
 		spy.restore.mockRejectedValueOnce(error);
 		await expect(cache.fromRemoteCache('3.20.1', 'yarn')).rejects.toBe(error);
-		expect(spy.fail).toBeCalledWith(error);
 	});
 });
 
 describe('toRemoteCache', () => {
 	const spy = {
-		fail: jest.spyOn(core, 'setFailed').mockImplementation(),
 		save: jest.spyOn(remoteCache, 'saveCache').mockImplementation(),
 	};
 
@@ -97,6 +93,5 @@ describe('toRemoteCache', () => {
 		const error = new Error('Remote cache save failed');
 		spy.save.mockRejectedValueOnce(error);
 		await expect(cache.toRemoteCache('/local/path', '3.20.1', 'yarn')).rejects.toBe(error);
-		expect(spy.fail).toBeCalledWith(error);
 	});
 });

--- a/tests/expo.test.ts
+++ b/tests/expo.test.ts
@@ -7,20 +7,17 @@ describe('authenticate', () => {
 	const spy = {
 		exec: jest.spyOn(cli, 'exec').mockImplementation(),
 		info: jest.spyOn(core, 'info').mockImplementation(),
-		fail: jest.spyOn(core, 'setFailed').mockImplementation(),
 	};
 
 	it('skips authentication without credentials', async () => {
 		await expo.authenticate('', '');
 		expect(spy.exec).not.toBeCalled();
-		expect(spy.fail).not.toBeCalled();
 		expect(spy.info).toBeCalled();
 	});
 
 	it('skips authentication without password', async () => {
 		await expo.authenticate('bycedric', '');
 		expect(spy.exec).not.toBeCalled();
-		expect(spy.fail).not.toBeCalled();
 		expect(spy.info).toBeCalled();
 	});
 
@@ -51,6 +48,5 @@ describe('authenticate', () => {
 		const error = new Error('Invalid username/password. Please try again.');
 		spy.exec.mockRejectedValue(error);
 		await expect(expo.authenticate('bycedric', 'incorrect')).rejects.toBe(error);
-		expect(spy.fail).toBeCalledWith(error);
 	});
 });


### PR DESCRIPTION
### Linked issue
Fixes the unhandled promise rejection with a global handler.

### Additional context
See [this run](https://github.com/byCedric/use-expo/pull/263/checks?check_run_id=656061231).
