### PR TITLE
fix: use inputs metadata key

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ branding:
 runs:
   using: node12
   main: build/index.js
-input:
+inputs:
   expo-version:
     description: The Expo CLI version to install. (use any semver/dist-tag available)
     default: latest


### PR DESCRIPTION
### Additional context
A warning is thrown while using the action that the inputs are not valid. This is a simple fix by using the correct metadata key (see https://help.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputs).