### PR TITLE
fix: proper space between icon and text

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ You can disable this patch by setting the `expo-patch-watchers` to `false`.
 
 <div align="center">
   <br />
-  with :heart: <strong>byCedric</strong>
+  with :heart: &nbsp; <strong>byCedric</strong>
   <br />
 </div>
 


### PR DESCRIPTION
### Additional context
Rasing PR to make sure, there is proper spacing between the `:heart: icon and the text`.
