### PR TITLE
refactor: group output by steps for readability

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,5 +22,6 @@ module.exports = {
 		'@typescript-eslint/indent': ['error', 'tab'],
 		'@typescript-eslint/no-non-null-assertion': 'off',
 		'@typescript-eslint/no-use-before-define': 'off',
+		'@typescript-eslint/no-explicit-any': 'off',
 	},
 };

--- a/src/expo.ts
+++ b/src/expo.ts
@@ -67,4 +67,5 @@ export function authenticate(options: AuthOptions) {
 	}
 
 	core.info('Skipping authentication: `expo-token`, `expo-username`, and/or `expo-password` not set...');
+	return Promise.resolve();
 }

--- a/src/install.ts
+++ b/src/install.ts
@@ -7,7 +7,7 @@ import { fromLocalCache, fromRemoteCache, toLocalCache, toRemoteCache } from './
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const registry = require('libnpm');
 
-type InstallConfig = {
+export type InstallConfig = {
 	version: string;
 	packager: string;
 	cache?: boolean;

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -1,4 +1,8 @@
-const core = { addPath: jest.fn(), getInput: jest.fn() };
+const core = {
+	addPath: jest.fn(),
+	getInput: jest.fn(),
+	group: (message: string, action: () => Promise<any>) => action()
+};
 const exec = { exec: jest.fn() };
 const expo = { authenticate: jest.fn() };
 const install = { install: jest.fn() };


### PR DESCRIPTION
### Linked issue
None, but this improves readability of the output. It's grouped by sections instead of dumped in a big list. Outputs like yarn install are hidden under "Installing Expo CLI with yarn" or "Installing Expo CLI from cache or with yarn".