### PR TITLE
fix: add support for environments without remote cache

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -83,8 +83,8 @@ function handleRemoteCacheError(error: Error): boolean {
 	);
 
 	if (isReserveCacheError || isCacheUnavailable) {
-		core.info('Skipping remote cache storage, encountered error:');
-		core.info(error.message);
+		core.warning('Skipping remote cache storage, encountered error:');
+		core.warning(error.message);
 		return true;
 	}
 

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -74,6 +74,13 @@ describe('fromRemoteCache', () => {
 		spy.restore.mockRejectedValueOnce(error);
 		await expect(cache.fromRemoteCache('3.20.1', 'yarn')).rejects.toBe(error);
 	});
+
+	it('skips remote cache when unavailable', async () => {
+		// see: https://github.com/actions/toolkit/blob/9167ce1f3a32ad495fc1dbcb574c03c0e013ae53/packages/cache/src/internal/cacheHttpClient.ts#L41
+		const error = new Error('Cache Service Url not found, unable to restore cache.');
+		spy.restore.mockRejectedValueOnce(error);
+		await expect(cache.fromRemoteCache('3.20.1', 'yarn')).resolves.toBeUndefined();
+	});
 });
 
 describe('toRemoteCache', () => {
@@ -106,5 +113,12 @@ describe('toRemoteCache', () => {
 		const error = new Error('Remote cache save failed');
 		spy.save.mockRejectedValueOnce(error);
 		await expect(cache.toRemoteCache(join('local', 'path'), '3.20.1', 'yarn')).rejects.toBe(error);
+	});
+
+	it('skips remote cache when unavailable', async () => {
+		// see: https://github.com/actions/toolkit/blob/9167ce1f3a32ad495fc1dbcb574c03c0e013ae53/packages/cache/src/internal/cacheHttpClient.ts#L41
+		const error = new Error('Cache Service Url not found, unable to restore cache.');
+		spy.save.mockRejectedValueOnce(error);
+		await expect(cache.toRemoteCache(join('local', 'path'), '3.20.1', 'yarn')).resolves.toBeUndefined();
 	});
 });


### PR DESCRIPTION
### Linked issue
Testing your workflow in Github actions might not be the best DX. Having this action work with [nektos/act](https://github.com/nektos/act) would be great to have.

fixes #90

### The change
I was looking at detecting if the action is running in the `act` environment, by checking if the `ACT` environment variable is set. But, I assume the cache might not always be available, like on custom runners or enterprise Github users. Instead of checking on the `ACT` env var, I opted to go for improved error handling.

Right now it checks on these two errors:
- If the cache is reserved by a parallel job, using the [`ReserveCacheError`](https://github.com/actions/toolkit/blob/main/packages/cache/src/cache.ts#L152)
- If the error message mentions [`Cache Service Url not found`](https://github.com/actions/toolkit/blob/main/packages/cache/src/internal/cacheHttpClient.ts#L41).

### Additional context
- Adding error handling is tricky, we should _never_ obfuscate the actual error. That's why I kept the error report in two lines:
  1. Describing what the action will do with this error.
  2. Passing the actual encountered error for debugging purposes.

- Another thing I noticed is if you forgot to add the secret, and Expo requires to authenticate, it fails to recognize the CLI is running in non-interactive mode. I think that might be an error in act, if you run into this you have to manually force close docker/cli.

### How to use it

I've run this change locally on [bycedric/office-marathon](https://github.com/bycedric/office-marathon) using the smallest Docker instance from act. That seems to work fine!

```
$ act --secrets EXPO_TOKEN=<token>
```

That should produce this output:

From cache | To cache
--- | ---
![Screenshot 2021-06-16 at 15 45 37](https://user-images.githubusercontent.com/1203991/122230462-f9ca7a00-ceb9-11eb-8818-25553cbd8a1c.png) | ![Screenshot 2021-06-16 at 15 47 04](https://user-images.githubusercontent.com/1203991/122230627-1b2b6600-ceba-11eb-90b0-e07a2d860883.png)

