### PR TITLE
feature!: add support for eas cli installs

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -16,7 +16,12 @@ module.exports = {
   plugins: [
     ['@semantic-release/commit-analyzer', {
       preset: 'conventionalcommits',
-      releaseRules: rules.map(({ type, release }) => ({ type, release })),
+      releaseRules: [
+				{ breaking: true, release: 'major' },
+				{ revert: true, release: 'patch' },
+			].concat(
+				rules.map(({ type, release, breaking }) => ({ type, release, breaking }))
+			),
     }],
     ['@semantic-release/release-notes-generator', {
       preset: 'conventionalcommits',

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ## What's inside?
 
-With this Expo action, you have full access to the [Expo CLI][link-expo-cli] itself.
+With this Expo action, you have full access to [Expo CLI][link-expo-cli] and [EAS CLI][link-eas-cli] itself.
 It allows you to fully automate the `expo publish` or `expo build` process, leaving you with more time available for your project.
 There are some additional features included to make the usage of this action as simple as possible, like caching and authentication.
 
@@ -37,19 +37,19 @@ There are some additional features included to make the usage of this action as 
 This action is customizable through variables; they are defined in the [`action.yml`](action.yml).
 Here is a summary of all the variables that you can use and their purpose.
 
-| variable         | default | description                                                                                           |
-| ---------------- | ------- | ----------------------------------------------------------------------------------------------------- |
-| `expo-version`   | -       | [Expo CLI](https://github.com/expo/expo-cli) version to install, skips when omitted.                  |
-| `expo-cache`     | `false` | If it should use the [GitHub actions (remote) cache](#using-the-built-in-cache).                      |
-| `expo-cache-key` | -       | An optional custom (remote) cache key. _(**use with caution**)_                                       |
-| `eas-version`    | -       | [EAS CLI](https://github.com/expo/eas-cli) version to install, skips when omitted.                    |
-| `eas-cache`      | `false` | If it should use the [GitHub actions (remote) cache](#using-the-built-in-cache).                      |
-| `eas-cache-key`  | -       | An optional custom (remote) cache key. _(**use with caution**)_                                       |
-| `packager`       | `yarn`  | The package manager to use. _(e.g. `npm`)_                                                            |
-| `token`          | -       | The token of your Expo account _(e.g. [`${{ secrets.EXPO_TOKEN }}`][link-actions-secrets])_           |
-| `username`       | -       | The username of your Expo account _(e.g. `bycedric`)_                                                 |
-| `password`       | -       | The password of your Expo account _(e.g. [`${{ secrets.EXPO_CLI_PASSWORD }}`][link-actions-secrets])_ |
-| `patch-watchers` | `true`  | If it should [patch the `fs.inotify.` limits](#enospc-errors-on-linux).                               |
+| variable         | default | description                                                                                                  |
+| ---------------- | ------- | ------------------------------------------------------------------------------------------------------------ |
+| `expo-version`   | -       | [Expo CLI](https://github.com/expo/expo-cli) version to install, skips when omitted.                         |
+| `expo-cache`     | `false` | If it should use the [GitHub actions (remote) cache](#using-the-built-in-cache).                             |
+| `expo-cache-key` | -       | An optional custom (remote) cache key. _(**use with caution**)_                                              |
+| `eas-version`    | -       | [EAS CLI](https://github.com/expo/eas-cli) version to install, skips when omitted. (`latest` is recommended) |
+| `eas-cache`      | `false` | If it should use the [GitHub actions (remote) cache](#using-the-built-in-cache).                             |
+| `eas-cache-key`  | -       | An optional custom (remote) cache key. _(**use with caution**)_                                              |
+| `packager`       | `yarn`  | The package manager to use. _(e.g. `npm`)_                                                                   |
+| `token`          | -       | The token of your Expo account _(e.g. [`${{ secrets.EXPO_TOKEN }}`][link-actions-secrets])_                  |
+| `username`       | -       | The username of your Expo account _(e.g. `bycedric`)_                                                        |
+| `password`       | -       | The password of your Expo account _(e.g. [`${{ secrets.EXPO_CLI_PASSWORD }}`][link-actions-secrets])_        |
+| `patch-watchers` | `true`  | If it should [patch the `fs.inotify.` limits](#enospc-errors-on-linux).                                      |
 
 > Never hardcode `expo-token` or `expo-password` in your workflow, use [secrets][link-actions-secrets] to store them.
 
@@ -129,11 +129,11 @@ jobs:
 
 ### Creating a new EAS build
 
-You can also install EAS CLI with this Github Action.
+You can also install [EAS](https://docs.expo.io/eas/) CLI with this Github Action.
 Below we've swapped `expo-version` with `eas-version`, but you can also use them together.
 Both the `token` and `username`/`password` is shared between both Expo and EAS CLI.
 
-> You can [read more about EAS here](https://docs.expo.io/eas/)
+> We recommend using `latest` for `eas-version` to always have the most up-to-date version.
 
 ```yml
 name: EAS build
@@ -152,8 +152,7 @@ jobs:
           node-version: 14.x
       - uses: expo/expo-github-action@v5
         with:
-          eas-version: ^0.17.0
-          eas-cache: true
+          eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
       - run: yarn install
       - run: eas build
@@ -320,4 +319,5 @@ You can disable this patch by setting the `patch-watchers` to `false`.
 [link-expo-cli]: https://docs.expo.io/workflow/expo-cli/
 [link-expo-cli-password]: https://github.com/expo/expo-cli/blob/master/packages/expo-cli/src/accounts.ts#L88-L90
 [link-expo-release-channels]: https://docs.expo.io/distribution/release-channels/
+[link-eas-cli]: https://github.com/expo/eas-cli#readme
 [link-semver-playground]: https://semver.npmjs.com/

--- a/README.md
+++ b/README.md
@@ -37,20 +37,21 @@ There are some additional features included to make the usage of this action as 
 This action is customizable through variables; they are defined in the [`action.yml`](action.yml).
 Here is a summary of all the variables that you can use and their purpose.
 
-variable              | default  | description
----                   | ---      | ---
-`expo-username`       | -        | The username of your Expo account _(e.g. `bycedric`)_
-`expo-token`          | -        | The token of your Expo account _(e.g. [`${{ secrets.EXPO_TOKEN }}`][link-actions-secrets])_
-`expo-password`       | -        | The password of your Expo account _(e.g. [`${{ secrets.EXPO_CLI_PASSWORD }}`][link-actions-secrets])_
-`expo-version`        | `latest` | The Expo CLI version to use, can be any [SemVer][link-semver-playground]. _(e.g. `3.x`)_
-`expo-packager`       | `yarn`   | The package manager to install the CLI with. _(e.g. `npm`)_
-`expo-cache`          | `false`  | If it should use the [GitHub actions (remote) cache](#using-the-built-in-cache).
-`expo-cache-key`      | -        | An optional custom (remote) cache key. _(**use with caution**)_
-`expo-patch-watchers` | `true`   | If it should [patch the `fs.inotify.` limits](#enospc-errors-on-linux).
+| variable         | default | description                                                                                           |
+| ---------------- | ------- | ----------------------------------------------------------------------------------------------------- |
+| `expo-version`   | -       | [Expo CLI](https://github.com/expo/expo-cli) version to install, skips when omitted.                  |
+| `expo-cache`     | `false` | If it should use the [GitHub actions (remote) cache](#using-the-built-in-cache).                      |
+| `expo-cache-key` | -       | An optional custom (remote) cache key. _(**use with caution**)_                                       |
+| `eas-version`    | -       | [EAS CLI](https://github.com/expo/eas-cli) version to install, skips when omitted.                    |
+| `eas-cache`      | `false` | If it should use the [GitHub actions (remote) cache](#using-the-built-in-cache).                      |
+| `eas-cache-key`  | -       | An optional custom (remote) cache key. _(**use with caution**)_                                       |
+| `packager`       | `yarn`  | The package manager to use. _(e.g. `npm`)_                                                            |
+| `token`          | -       | The token of your Expo account _(e.g. [`${{ secrets.EXPO_TOKEN }}`][link-actions-secrets])_           |
+| `username`       | -       | The username of your Expo account _(e.g. `bycedric`)_                                                 |
+| `password`       | -       | The password of your Expo account _(e.g. [`${{ secrets.EXPO_CLI_PASSWORD }}`][link-actions-secrets])_ |
+| `patch-watchers` | `true`  | If it should [patch the `fs.inotify.` limits](#enospc-errors-on-linux).                               |
 
 > Never hardcode `expo-token` or `expo-password` in your workflow, use [secrets][link-actions-secrets] to store them.
-
-> It's also recommended to set the `expo-version` to avoid breaking changes when a new major version is released.
 
 ## Example workflows
 
@@ -59,16 +60,17 @@ You can read more about this in the [GitHub Actions documentation][link-actions]
 
 1. [Publish on any push to master](#publish-on-any-push-to-master)
 2. [Cache Expo CLI for other jobs](#cache-expo-cli-for-other-jobs)
-3. [Test PRs and publish a review version](#test-prs-and-publish-a-review-version)
-4. [Test PRs on multiple nodes and systems](#test-prs-on-multiple-nodes-and-systems)
-5. [Test and build web every day at 08:00](#test-and-build-web-every-day-at-0800)
-6. [Authenticate using an Expo token](#authenticate-using-an-expo-token)
+3. [Creating a new EAS build](#publish-on-any-push-to-master)
+4. [Test PRs and publish a review version](#test-prs-and-publish-a-review-version)
+5. [Test PRs on multiple nodes and systems](#test-prs-on-multiple-nodes-and-systems)
+6. [Test and build web every day at 08:00](#test-and-build-web-every-day-at-0800)
+7. [Authenticate using credentials](#authenticate-using-credentials)
 
 ### Publish on any push to master
 
 Below you can see the example configuration to publish whenever the master branch is updated.
 The workflow listens to the `push` event and sets up Node 12 using the [Setup Node Action][link-actions-node].
-It also authenticates the Expo project by defining both `expo-username` and `expo-password`.
+It also auto-authenticates when the `token` is provided.
 
 ```yml
 name: Expo Publish
@@ -88,8 +90,7 @@ jobs:
       - uses: expo/expo-github-action@v5
         with:
           expo-version: 4.x
-          expo-username: ${{ secrets.EXPO_CLI_USERNAME }}
-          expo-password: ${{ secrets.EXPO_CLI_PASSWORD }}
+          token: ${{ secrets.EXPO_TOKEN }}
       - run: yarn install
       - run: expo publish
 ```
@@ -120,11 +121,42 @@ jobs:
       - uses: expo/expo-github-action@v5
         with:
           expo-version: 4.x
-          expo-username: ${{ secrets.EXPO_CLI_USERNAME }}
-          expo-password: ${{ secrets.EXPO_CLI_PASSWORD }}
           expo-cache: true
+          token: ${{ secrets.EXPO_TOKEN }}
       - run: yarn install
       - run: expo publish
+```
+
+### Creating a new EAS build
+
+You can also install EAS CLI with this Github Action.
+Below we've swapped `expo-version` with `eas-version`, but you can also use them together.
+Both the `token` and `username`/`password` is shared between both Expo and EAS CLI.
+
+> You can [read more about EAS here](https://docs.expo.io/eas/)
+
+```yml
+name: EAS build
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    name: Create new build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+      - uses: expo/expo-github-action@v5
+        with:
+          eas-version: ^0.17.0
+          eas-cache: true
+          token: ${{ secrets.EXPO_TOKEN }}
+      - run: yarn install
+      - run: eas build
 ```
 
 ### Test PRs and publish a review version
@@ -148,8 +180,7 @@ jobs:
       - uses: expo/expo-github-action@v5
         with:
           expo-version: 4.x
-          expo-username: ${{ secrets.EXPO_CLI_USERNAME }}
-          expo-password: ${{ secrets.EXPO_CLI_PASSWORD }}
+          token: ${{ secrets.EXPO_TOKEN }}
       - run: yarn install
       - run: expo publish --release-channel=pr-${{ github.event.number }}
       - uses: unsplash/comment-on-pr@master
@@ -164,7 +195,7 @@ jobs:
 With GitHub Actions, it's reasonably easy to set up a matrix build and test the app on multiple environments.
 These matrixes can help to make sure your app runs smoothly on a broad set of different development machines.
 
-> If you don't need automatic authentication, you can omit the `expo-username` and `expo-password` variables.
+> If you don't need automatic authentication, you can omit the `token` variables.
 
 ```yml
 name: Expo CI
@@ -217,10 +248,10 @@ jobs:
       - run: expo build:web
 ```
 
-### Authenticate using an Expo token
+### Authenticate using credentials
 
-Instead of username and password, you can also authenticate using a token.
-This might help increasing security and avoids adding username and password to your repository secrets.
+Instead of using an access token, you can also authenticate using credentials.
+This is only possible when Expo CLI is installed.
 
 ```yml
 name: Expo Publish
@@ -240,7 +271,8 @@ jobs:
       - uses: expo/expo-github-action@v5
         with:
           expo-version: 4.x
-          expo-token: ${{ secrets.EXPO_TOKEN }}
+          username: ${{ secrets.EXPO_CLI_USERNAME }}
+          password: ${{ secrets.EXPO_CLI_PASSWORD }}
       - run: yarn install
       - run: expo publish
 ```
@@ -263,7 +295,7 @@ Under the hood, it uses the [`@action/cache`][link-actions-cache-package] packag
 This action generates a unique cache key for the OS, used packager, and exact version of the Expo CLI.
 If you need more control over this cache, you can define a custom cache key with `expo-cache-key`.
 
-> Note, this cache will count towards your [repo cache limit][link-actions-cache-limit].
+> Note, this cache will count towards your [repo cache limit][link-actions-cache-limit]. The Expo and EAS CLI are stored in different caches.
 
 ### ENOSPC errors on Linux
 
@@ -272,7 +304,7 @@ Creating these bundles require quite some resources.
 As of writing, GitHub actions has some small default values for the `fs.inotify` settings.
 Inside this action, we included a patch that increases these limits for the current workflow.
 It increases the `max_user_instances`, `max_user_watches` and `max_queued_events` to `524288`.
-You can disable this patch by setting the `expo-patch-watchers` to `false`.
+You can disable this patch by setting the `patch-watchers` to `false`.
 
 <div align="center">
   <br />

--- a/action.yml
+++ b/action.yml
@@ -10,22 +10,28 @@ runs:
   main: build/index.js
 inputs:
   expo-version:
-    description: The Expo CLI version to install. (use any semver/dist-tag available)
-    default: latest
-  expo-username:
-    description: Your Expo username, for authentication.
-  expo-token:
-    description: Your Expo token, for authentication. (use with secrets)
-  expo-password:
-    description: Your Expo password, for authentication. (use with secrets)
-  expo-packager:
-    description: The package manager used to install the Expo CLI. (can be yarn or npm)
-    default: yarn
-  expo-patch-watchers:
-    description: If Expo should fix the default watchers limit, helps with ENOSPC errors. (can be true or false)
-    default: true
+    description: The Expo CLI version to install (use any semver/dist-tag available).
   expo-cache:
-    description: If Expo should be stored in the GitHub Actions cache (can be true or false)
+    description: If Expo CLI should be stored in the GitHub Actions cache.
     default: false
   expo-cache-key:
-    description: A custom remote cache key to use (best to let GitHub Actions handle it)
+    description: A custom remote cache key to use for Expo CLI.
+  eas-version:
+    description: The EAS CLI version to install (use any semver/dist-tag available).
+  eas-cache:
+    description: If EAS CLI should be stored in the GitHub Actions cache.
+    default: false
+  eas-cache-key:
+    description: A custom remote cache key to use for EAS CLI.
+  username:
+    description: Your Expo username, for authentication.
+  token:
+    description: Your Expo token, for authentication. (use with secrets)
+  password:
+    description: Your Expo password, for authentication. (use with secrets)
+  packager:
+    description: The package manager used to install the Expo CLI. (can be yarn or npm)
+    default: yarn
+  patch-watchers:
+    description: If Expo should fix the default watchers limit, helps with ENOSPC errors. (can be true or false)
+    default: true

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
 import { run } from './run';
-import { handleError } from './tools';
 
-run().catch(handleError);
+run();

--- a/src/install.ts
+++ b/src/install.ts
@@ -4,11 +4,18 @@ import * as io from '@actions/io';
 import * as path from 'path';
 
 import { fromLocalCache, fromRemoteCache, toLocalCache, toRemoteCache } from './cache';
+import { PackageName } from './tools';
 
 export type InstallConfig = {
+	/** The exact version to install */
 	version: string;
+	/** The name of the package to install */
+	package: PackageName;
+	/** The packager to install with, likely to be `yarn` or `npm` */
 	packager: string;
+	/** If remote caching is enabled or not */
 	cache?: boolean;
+	/** The custom remote cache key */
 	cacheKey?: string;
 };
 
@@ -18,20 +25,20 @@ export type InstallConfig = {
  * It returns the path where Expo is installed.
  */
 export async function install(config: InstallConfig): Promise<string> {
-	let root: string | undefined = await fromLocalCache(config.version);
+	let root: string | undefined = await fromLocalCache(config);
 
 	if (!root && config.cache) {
-		root = await fromRemoteCache(config.version, config.packager, config.cacheKey);
+		root = await fromRemoteCache(config);
 	} else {
 		core.info('Skipping remote cache, not enabled...');
 	}
 
 	if (!root) {
-		root = await fromPackager(config.version, config.packager);
-		root = await toLocalCache(root, config.version);
+		root = await fromPackager(config);
+		root = await toLocalCache(root, config);
 
 		if (config.cache) {
-			await toRemoteCache(root, config.version, config.packager, config.cacheKey);
+			await toRemoteCache(root, config);
 		}
 	}
 
@@ -42,12 +49,12 @@ export async function install(config: InstallConfig): Promise<string> {
  * Install `expo-cli`, by version, using npm or yarn.
  * It creates a temporary directory to store all required files.
  */
-export async function fromPackager(version: string, packager: string): Promise<string> {
+export async function fromPackager(config: InstallConfig): Promise<string> {
 	const root = process.env['RUNNER_TEMP'] || '';
-	const tool = await io.which(packager);
+	const tool = await io.which(config.packager);
 
 	await io.mkdirP(root);
-	await cli.exec(tool, ['add', `expo-cli@${version}`], { cwd: root });
+	await cli.exec(tool, ['add', `${config.package}@${config.version}`], { cwd: root });
 
 	return root;
 }

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -7,29 +7,29 @@ import * as toolCache from '@actions/tool-cache';
 import * as cache from '../src/cache';
 import * as utils from './utils';
 
-describe('fromLocalCache', () => {
+describe(cache.fromLocalCache, () => {
 	it('fetches the version specific cache', async () => {
 		const path = join('path', 'to', 'local', 'cache');
 		// todo: check why jest wants `never` instead of `string`
 		const find = jest.spyOn(toolCache, 'find').mockResolvedValue(path as never);
-		const result = await cache.fromLocalCache('3.20.1');
+		const result = await cache.fromLocalCache({ package: 'eas-cli', version: '4.2.0', packager: 'npm' });
 		expect(result).toBe(path);
-		expect(find).toBeCalledWith('expo-cli', '3.20.1');
+		expect(find).toBeCalledWith('eas-cli', '4.2.0');
 	});
 });
 
-describe('toLocalCache', () => {
+describe(cache.toLocalCache, () => {
 	it('stores the version specific cache', async () => {
 		const path = join('path', 'to', 'local', 'cache');
 		const root = join('path', 'from', 'source');
 		const cacheDir = jest.spyOn(toolCache, 'cacheDir').mockResolvedValue(path);
-		const result = await cache.toLocalCache(root, '3.20.1');
+		const result = await cache.toLocalCache(root, { package: 'expo-cli', version: '4.2.0', packager: 'yarn' });
 		expect(result).toBe(path);
-		expect(cacheDir).toBeCalledWith(root, 'expo-cli', '3.20.1');
+		expect(cacheDir).toBeCalledWith(root, 'expo-cli', '4.2.0');
 	});
 });
 
-describe('fromRemoteCache', () => {
+describe(cache.fromRemoteCache, () => {
 	let spy: { [key: string]: jest.SpyInstance } = {};
 
 	beforeEach(() => {
@@ -50,7 +50,7 @@ describe('fromRemoteCache', () => {
 	});
 
 	it('restores remote cache with default key', async () => {
-		expect(await cache.fromRemoteCache('3.20.1', 'yarn')).toBeUndefined();
+		expect(await cache.fromRemoteCache({ package: 'expo-cli', version: '3.20.1', packager: 'yarn' })).toBeUndefined();
 		expect(remoteCache.restoreCache).toBeCalledWith(
 			[join('cache', 'path', 'expo-cli', '3.20.1', os.arch())],
 			`expo-cli-${process.platform}-${os.arch()}-yarn-3.20.1`,
@@ -58,36 +58,45 @@ describe('fromRemoteCache', () => {
 	});
 
 	it('restores remote cache with custom key', async () => {
-		expect(await cache.fromRemoteCache('3.20.0', 'yarn', 'custom-cache-key')).toBeUndefined();
+		expect(
+			await cache.fromRemoteCache({
+				package: 'eas-cli',
+				version: '4.2.0',
+				packager: 'yarn',
+				cacheKey: 'custom-cache-key',
+			})
+		).toBeUndefined();
 		expect(remoteCache.restoreCache).toBeCalledWith(
-			[join('cache', 'path', 'expo-cli', '3.20.0', os.arch())],
+			[join('cache', 'path', 'eas-cli', '4.2.0', os.arch())],
 			'custom-cache-key',
 		);
 	});
 
 	it('returns path when remote cache exists', async () => {
 		spy.restore.mockResolvedValueOnce(true);
-		await expect(cache.fromRemoteCache('3.20.1', 'npm')).resolves.toBe(
-			join('cache', 'path', 'expo-cli', '3.20.1', os.arch())
-		);
+		expect(
+			await cache.fromRemoteCache({ package: 'expo-cli', version: '3.20.1', packager: 'npm' })
+		).toBe(join('cache', 'path', 'expo-cli', '3.20.1', os.arch()));
 	});
 
 	it('fails when remote cache throws', async () => {
 		const error = new Error('Remote cache restore failed');
 		spy.restore.mockRejectedValueOnce(error);
-		await expect(cache.fromRemoteCache('3.20.1', 'yarn')).rejects.toBe(error);
+		await expect(cache.fromRemoteCache({ package: 'eas-cli', version: '3.20.1', packager: 'yarn' })).rejects.toBe(error);
 	});
 
 	it('skips remote cache when unavailable', async () => {
 		// see: https://github.com/actions/toolkit/blob/9167ce1f3a32ad495fc1dbcb574c03c0e013ae53/packages/cache/src/internal/cacheHttpClient.ts#L41
 		const error = new Error('Cache Service Url not found, unable to restore cache.');
 		spy.restore.mockRejectedValueOnce(error);
-		await expect(cache.fromRemoteCache('3.20.1', 'yarn')).resolves.toBeUndefined();
+		expect(
+			await cache.fromRemoteCache({ package: 'expo-cli', version: '3.20.1', packager: 'yarn' })
+		).toBeUndefined();
 		expect(spy.warning).toHaveBeenCalledWith(expect.stringContaining('Skipping remote cache'));
 	});
 });
 
-describe('toRemoteCache', () => {
+describe(cache.toRemoteCache, () => {
 	let spy: { [key: string]: jest.SpyInstance } = {};
 
 	beforeEach(() => {
@@ -103,29 +112,38 @@ describe('toRemoteCache', () => {
 	});
 
 	it('saves remote cache with default key', async () => {
-		expect(await cache.toRemoteCache(join('local', 'path'), '3.20.1', 'npm')).toBeUndefined();
+		expect(await cache.toRemoteCache(join('local', 'path'), { package: 'eas-cli', version: '3.20.1', packager: 'npm' })).toBeUndefined();
 		expect(remoteCache.saveCache).toBeCalledWith(
 			[join('local', 'path')],
-			`expo-cli-${process.platform}-${os.arch()}-npm-3.20.1`
+			`eas-cli-${process.platform}-${os.arch()}-npm-3.20.1`
 		);
 	});
 
 	it('saves remote cache with custom key', async () => {
-		expect(await cache.toRemoteCache(join('local', 'path'), '3.20.1', 'yarn', 'custom-cache-key')).toBeUndefined();
+		expect(await cache.toRemoteCache(
+			join('local', 'path'),
+			{ package: 'eas-cli', version: '3.20.1', packager: 'yarn', cacheKey: 'custom-cache-key' }
+		)).toBeUndefined();
 		expect(remoteCache.saveCache).toBeCalledWith([join('local', 'path')], 'custom-cache-key');
 	});
 
 	it('fails when remote cache throws', async () => {
 		const error = new Error('Remote cache save failed');
 		spy.save.mockRejectedValueOnce(error);
-		await expect(cache.toRemoteCache(join('local', 'path'), '3.20.1', 'yarn')).rejects.toBe(error);
+		await expect(cache.toRemoteCache(
+			join('local', 'path'),
+			{ package: 'expo-cli', version: '3.20.1', packager: 'yarn' },
+		)).rejects.toBe(error);
 	});
 
 	it('skips remote cache when unavailable', async () => {
 		// see: https://github.com/actions/toolkit/blob/9167ce1f3a32ad495fc1dbcb574c03c0e013ae53/packages/cache/src/internal/cacheHttpClient.ts#L41
 		const error = new Error('Cache Service Url not found, unable to restore cache.');
 		spy.save.mockRejectedValueOnce(error);
-		await expect(cache.toRemoteCache(join('local', 'path'), '3.20.1', 'yarn')).resolves.toBeUndefined();
+		await expect(cache.toRemoteCache(
+			join('local', 'path'),
+			{ package: 'expo-cli', version: '3.20.1', packager: 'yarn' },
+		)).resolves.toBeUndefined();
 		expect(spy.warning).toHaveBeenCalledWith(expect.stringContaining('Skipping remote cache'));
 	});
 });

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -19,7 +19,7 @@ import * as utils from './utils';
 describe('install', () => {
 	it('installs path from local cache', async () => {
 		cache.fromLocalCache.mockResolvedValue(join('cache', 'path'));
-		const expoPath = await install.install({ version: '3.0.10', packager: 'npm' });
+		const expoPath = await install.install({ package: 'expo-cli', version: '3.0.10', packager: 'npm' });
 		expect(expoPath).toBe(join('cache', 'path', 'node_modules', '.bin'));
 	});
 
@@ -27,18 +27,18 @@ describe('install', () => {
 		utils.setEnv('RUNNER_TEMP', join('temp', 'path'));
 		cache.fromLocalCache.mockResolvedValue(undefined);
 		cache.toLocalCache.mockResolvedValue(join('cache', 'path'));
-		const expoPath = await install.install({ version: '3.0.10', packager: 'npm' });
+		const expoPath = await install.install({ package: 'expo-cli', version: '3.0.10', packager: 'npm' });
 		expect(expoPath).toBe(join('cache', 'path', 'node_modules', '.bin'));
-		expect(cache.toLocalCache).toBeCalledWith(join('temp', 'path'), '3.0.10');
+		expect(cache.toLocalCache).toBeCalledWith(join('temp', 'path'), { package: 'expo-cli', version: '3.0.10', packager: 'npm' });
 		utils.restoreEnv();
 	});
 
 	it('installs path from remote cache', async () => {
 		cache.fromLocalCache.mockResolvedValue(undefined);
 		cache.fromRemoteCache.mockResolvedValue(join('cache', 'path'));
-		const expoPath = await install.install({ version: '3.20.1', packager: 'npm', cache: true });
+		const expoPath = await install.install({ package: 'eas-cli', version: '4.2.0', packager: 'yarn', cache: true });
 		expect(expoPath).toBe(join('cache', 'path', 'node_modules', '.bin'));
-		expect(cache.fromRemoteCache).toBeCalledWith('3.20.1', 'npm', undefined);
+		expect(cache.fromRemoteCache).toBeCalledWith({ package: 'eas-cli', version: '4.2.0', packager: 'yarn', cache: true });
 	});
 
 	it('installs path from packager and cache it remotely', async () => {
@@ -46,22 +46,22 @@ describe('install', () => {
 		cache.fromLocalCache.mockResolvedValue(undefined);
 		cache.fromRemoteCache.mockResolvedValue(undefined);
 		cache.toLocalCache.mockResolvedValue(join('cache', 'path'));
-		const expoPath = await install.install({ version: '3.20.1', packager: 'npm', cache: true });
+		const expoPath = await install.install({ package: 'expo-cli', version: '3.20.1', packager: 'npm', cache: true });
 		expect(expoPath).toBe(join('cache', 'path', 'node_modules', '.bin'));
-		expect(cache.toRemoteCache).toBeCalledWith(join('cache', 'path'), '3.20.1', 'npm', undefined);
+		expect(cache.toRemoteCache).toBeCalledWith(join('cache', 'path'), { package: 'expo-cli', version: '3.20.1', packager: 'npm', cache: true });
 		utils.restoreEnv();
 	});
 });
 
 describe('fromPackager', () => {
 	it('resolves tool path', async () => {
-		await install.fromPackager('3.0.10', 'npm');
+		await install.fromPackager({ package: 'expo-cli', version: '3.0.10', packager: 'npm' });
 		expect(io.which).toBeCalledWith('npm');
 	});
 
 	it('creates temporary folder', async () => {
 		utils.setEnv('RUNNER_TEMP', join('temp', 'path'));
-		await install.fromPackager('latest', 'yarn');
+		await install.fromPackager({ package: 'eas-cli', version: 'latest', packager: 'yarn' });
 		expect(io.mkdirP).toBeCalledWith(join('temp', 'path'));
 		utils.restoreEnv();
 	});
@@ -69,11 +69,11 @@ describe('fromPackager', () => {
 	it('installs expo with tool', async () => {
 		utils.setEnv('RUNNER_TEMP', join('temp', 'path'));
 		io.which.mockResolvedValue('npm');
-		const expoPath = await install.fromPackager('beta', 'npm');
+		const expoPath = await install.fromPackager({ package: 'eas-cli', version: 'beta', packager: 'npm' });
 		expect(expoPath).toBe(join('temp', 'path'));
 		expect(cli.exec).toBeCalled();
 		expect(cli.exec.mock.calls[0][0]).toBe('npm');
-		expect(cli.exec.mock.calls[0][1]).toStrictEqual(['add', 'expo-cli@beta']);
+		expect(cli.exec.mock.calls[0][1]).toStrictEqual(['add', 'eas-cli@beta']);
 		expect(cli.exec.mock.calls[0][2]).toMatchObject({ cwd: join('temp', 'path') });
 		utils.restoreEnv();
 	});

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -1,12 +1,15 @@
 const core = {
 	addPath: jest.fn(),
 	getInput: jest.fn(),
-	group: (message: string, action: () => Promise<any>) => action()
+	group: (message: string, action: () => Promise<any>) => action(),
+	info: jest.fn(),
 };
 const exec = { exec: jest.fn() };
 const install = { install: jest.fn() };
 const tools = {
-	resolveVersion: jest.fn(v => v),
+	getBoolean: jest.fn((v, d) => v ? v === 'true' : d),
+	getBinaryName: jest.fn(v => v.replace('-cli', '')),
+	resolveVersion: jest.fn((n, v) => v),
 	maybeAuthenticate: jest.fn(),
 	maybePatchWatchers: jest.fn(),
 };
@@ -18,64 +21,7 @@ jest.mock('../src/install', () => install);
 
 import { run } from '../src/run';
 
-interface MockInputProps {
-	version?: string;
-	packager?: string;
-	token?: string;
-	username?: string;
-	password?: string;
-	patchWatchers?: string;
-	cache?: string;
-	cacheKey?: string;
-}
-
-const mockInput = (props: MockInputProps = {}) => {
-	// fix: kind of dirty workaround for missing "mock 'value' based on arguments"
-	const input = (name: string) => {
-		switch (name) {
-			case 'expo-version':
-				return props.version || '';
-			case 'expo-packager':
-				return props.packager || '';
-			case 'expo-token':
-				return props.token || '';
-			case 'expo-username':
-				return props.username || '';
-			case 'expo-password':
-				return props.password || '';
-			case 'expo-patch-watchers':
-				return props.patchWatchers || '';
-			case 'expo-cache':
-				return props.cache || '';
-			case 'expo-cache-key':
-				return props.cacheKey || '';
-			default:
-				return '';
-		}
-	};
-
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	core.getInput = input as any;
-};
-
 describe('run', () => {
-	it('installs latest expo-cli with yarn by default', async () => {
-		await run();
-		expect(install.install).toBeCalledWith({ version: 'latest', packager: 'yarn', cache: false });
-	});
-
-	it('installs provided version expo-cli with npm', async () => {
-		mockInput({ version: '3.0.10', packager: 'npm' });
-		await run();
-		expect(install.install).toBeCalledWith({ version: '3.0.10', packager: 'npm', cache: false });
-	});
-
-	it('installs path to global path', async () => {
-		install.install.mockResolvedValue('/expo/install/path');
-		await run();
-		expect(core.addPath).toBeCalledWith('/expo/install/path');
-	});
-
 	it('patches the system when set to true', async () => {
 		mockInput({ patchWatchers: 'true' });
 		await run();
@@ -105,4 +51,126 @@ describe('run', () => {
 		await run();
 		expect(tools.maybeAuthenticate).toBeCalledWith({ token: 'ABC123' });
 	});
+
+	['expo', 'eas'].forEach(cliName => {
+		const packageName = `${cliName}-cli`;
+
+		describe(packageName, () => {
+			it(`skips installation without \`${cliName}-version\``, async () => {
+				mockInput();
+				await run();
+				expect(install.install).not.toBeCalledWith({ package: packageName });
+			});
+
+			it('installs with yarn by default', async () => {
+				mockInput({ [`${cliName}Version`]: 'latest' });
+				await run();
+				expect(install.install).toBeCalledWith({
+					package:
+					packageName,
+					version: 'latest',
+					packager: 'yarn',
+					cache: false,
+				});
+			});
+
+			it('installs provided version with npm', async () => {
+				mockInput({ [`${cliName}Version`]: '3.0.10', packager: 'npm' });
+				await run();
+				expect(install.install).toBeCalledWith({
+					package: packageName,
+					version: '3.0.10',
+					packager: 'npm',
+					cache: false,
+				});
+			});
+
+			it('installs with yarn and cache enabled', async () => {
+				mockInput({
+					packager: 'yarn',
+					[`${cliName}Version`]: '4.2.0',
+					[`${cliName}Cache`]: 'true',
+				});
+				await run();
+				expect(install.install).toBeCalledWith({
+					package: packageName,
+					version: '4.2.0',
+					packager: 'yarn',
+					cache: true,
+				});
+			});
+
+			it('installs with yarn and custom cache key', async () => {
+				mockInput({
+					packager: 'yarn',
+					[`${cliName}Version`]: '4.2.0',
+					[`${cliName}Cache`]: 'true',
+					[`${cliName}CacheKey`]: 'custom-key'
+				});
+				await run();
+				expect(install.install).toBeCalledWith({
+					package: packageName,
+					version: '4.2.0',
+					packager: 'yarn',
+					cache: true,
+					cacheKey: 'custom-key',
+				});
+			});
+
+			it('installs path to global path', async () => {
+				install.install.mockResolvedValue(`/${cliName}/install/path`);
+				await run();
+				expect(core.addPath).toBeCalledWith(`/${cliName}/install/path`);
+			});
+		});
+	});
 });
+
+interface MockInputProps {
+	expoVersion?: string;
+	expoCache?: string;
+	expoCacheKey?: string;
+	easVersion?: string;
+	easCache?: string;
+	easCacheKey?: string;
+	packager?: string;
+	token?: string;
+	username?: string;
+	password?: string;
+	patchWatchers?: string;
+}
+
+function mockInput(props: MockInputProps = {}) {
+	// fix: kind of dirty workaround for missing "mock 'value' based on arguments"
+	const input = (name: string) => {
+		switch (name) {
+			case 'expo-version':
+				return props.expoVersion || '';
+			case 'expo-cache':
+				return props.expoCache || '';
+			case 'expo-cache-key':
+				return props.expoCacheKey || '';
+			case 'eas-version':
+				return props.easVersion || '';
+			case 'eas-cache':
+				return props.easCache || '';
+			case 'eas-cache-key':
+				return props.easCacheKey || '';
+			case 'packager':
+				return props.packager || '';
+			case 'token':
+				return props.token || '';
+			case 'username':
+				return props.username || '';
+			case 'password':
+				return props.password || '';
+			case 'patch-watchers':
+				return props.patchWatchers || '';
+			default:
+				return '';
+		}
+	};
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	core.getInput = input as any;
+}


### PR DESCRIPTION
BREAKING CHANGE: Github Action inputs are changed to allow both Expo and EAS CLI.

Part of #97 