### PR TITLE
docs: use `main` branch to update `v{major}` tag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ To release a new version for Github Actions, we have to create a new release in 
 After the exact version tag is created, update the `v{major}` tag to the latest major version. Make sure you are on the default branch at the commit of versioning.
 
 ```bash
-$ git checkout master
+$ git checkout main
 $ git fetch --tags && git pull
 $ git tag --force v{major}
 $ git push --force --tags


### PR DESCRIPTION
### Linked issue

#102 

I just happened to be reading through the docs and thought that this should have been updated. If tags are still being set using the `master` branch, feel free to dismiss this PR and close the linked issue. 😄 