### PR TITLE
Fix Example Code: Point to Different Branch for unsplash/comment-on-pr

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
       - run: yarn install
       - run: expo publish --release-channel=pr-${{ github.event.number }}
-      - uses: unsplash/comment-on-pr@main
+      - uses: unsplash/comment-on-pr@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
### Linked issue
https://github.com/expo/expo-github-action/issues/109

### Additional context
It looks like they still use `master` not `main`. This change resolved my issues. 
https://github.com/unsplash/comment-on-pr