### PR TITLE
Fix GitHub spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### ⚠ BREAKING CHANGES
 
-* Github Action inputs are changed to allow both Expo and EAS CLI.
+* GitHub Action inputs are changed to allow both Expo and EAS CLI.
 
 ### New features
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Expo Github Action
+# Contributing to Expo GitHub Action
 
 ## 📦 Download and Setup
 
@@ -10,9 +10,9 @@
 
 ## 🏎️ Running a custom version
 
-To try out your changed with Github Action, you have [to reference your fork and/or branch or commit reference](https://docs.github.com/en/actions/learn-github-actions/finding-and-customizing-actions#using-release-management-for-your-custom-actions) in the workflow you want to try. After that, you have two options:
+To try out your changed with GitHub Action, you have [to reference your fork and/or branch or commit reference](https://docs.github.com/en/actions/learn-github-actions/finding-and-customizing-actions#using-release-management-for-your-custom-actions) in the workflow you want to try. After that, you have two options:
 
-1. Run the workflow in Github Actions itself by triggering your workflow.
+1. Run the workflow in GitHub Actions itself by triggering your workflow.
 2. Run the workflow locally with [nektos/act](https://github.com/nektos/act).
 
 ## ✅ Testing
@@ -45,7 +45,7 @@ To get your PR merged as fast as possible, please make sure you have done the fo
 
 ## 🚀 Releasing a new version
 
-To release a new version for Github Actions, we have to create a new release in Github. You can run the `Release` workflow to generate a new version, changelog, and Github release.
+To release a new version for GitHub Actions, we have to create a new release in GitHub. You can run the `Release` workflow to generate a new version, changelog, and GitHub release.
 
 After the exact version tag is created, update the `v{major}` tag to the latest major version. Make sure you are on the default branch at the commit of versioning.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <h1>expo github action</h1>
   <p></p>
-  <p>Publish, build or manage your <a href="https://github.com/expo/expo">Expo</a> app with Github Actions!</p>
+  <p>Publish, build or manage your <a href="https://github.com/expo/expo">Expo</a> app with GitHub Actions!</p>
   <sup>
     <a href="https://github.com/expo/expo-github-action/releases">
       <img src="https://img.shields.io/github/release/expo/expo-github-action/all.svg?style=flat-square" alt="releases" />
@@ -131,7 +131,7 @@ jobs:
 
 ### Creating a new EAS build
 
-You can also install [EAS](https://docs.expo.dev/eas/) CLI with this Github Action.
+You can also install [EAS](https://docs.expo.dev/eas/) CLI with this GitHub Action.
 Below we've swapped `expo-version` with `eas-version`, but you can also use them together.
 Both the `token` and `username`/`password` is shared between both Expo and EAS CLI.
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -15,7 +15,7 @@ export type AuthenticateOptions = {
 };
 
 /**
- * Get a boolean value from string, useful for Github Actions boolean inputs.
+ * Get a boolean value from string, useful for GitHub Actions boolean inputs.
  */
 export function getBoolean(value: string, defaultValue = false): boolean {
 	return (value.toLowerCase() || (defaultValue ? 'true' : 'false')) === 'true';


### PR DESCRIPTION
Just a minor typo fix: `Github` -> `GitHub`.