### PR TITLE
update TSConfig, clean up ESLint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,14 +14,9 @@ module.exports = {
 		'plugin:@typescript-eslint/recommended',
 	],
 	rules: {
-		'@typescript-eslint/explicit-function-return-type': 'off',
 		'@typescript-eslint/explicit-member-accessibility': [
 			'error', { 'accessibility': 'no-public' },
 		],
-		'@typescript-eslint/explicit-module-boundary-types': 'off',
 		'@typescript-eslint/indent': ['error', 'tab'],
-		'@typescript-eslint/no-non-null-assertion': 'off',
-		'@typescript-eslint/no-use-before-define': 'off',
-		'@typescript-eslint/no-explicit-any': 'off',
 	},
 };

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -43,7 +43,7 @@ export async function fromRemoteCache(config: CacheConfig): Promise<string | und
 		if (hit) {
 			return target;
 		}
-	} catch (error: any) {
+	} catch (error) {
 		if (!handleRemoteCacheError(error)) {
 			throw error;
 		}
@@ -59,7 +59,7 @@ export async function toRemoteCache(source: string, config: CacheConfig): Promis
 
 	try {
 		await saveCache([source], cacheKey);
-	} catch (error: any) {
+	} catch (error) {
 		if (!handleRemoteCacheError(error)) {
 			throw error;
 		}

--- a/src/run.ts
+++ b/src/run.ts
@@ -50,7 +50,7 @@ async function installCli(name: tools.PackageName): Promise<string | void> {
 		);
 
 		addPath(path);
-	} catch (error: any) {
+	} catch (error) {
 		tools.handleError(name, error);
 	}
 

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -1,7 +1,7 @@
 const core = {
 	addPath: jest.fn(),
 	getInput: jest.fn(),
-	group: (message: string, action: () => Promise<any>) => action(),
+	group: <T>(message: string, action: () => Promise<T>): Promise<T> => action(),
 	info: jest.fn(),
 };
 const exec = { exec: jest.fn() };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"outDir": "./build",
 		"rootDir": "./src",
-		"noImplicitAny": false
+		"useUnknownInCatchVariables": false
 	},
 	"exclude": [
 		"build",


### PR DESCRIPTION
## Linked issue

Refs:
* #120

## Additional context

As suggested in the referenced PR I have added the `useUnknownInCatchVariables` ignore flag to the TSConfig instead of adding implicit `any`s.

I have also removed all of the disabled ESLint rules and `noImplicitAny` flag from the TSConfig. This resulted in only in one warning in the codebase related to Jest mock, which I was able to fix by mimicking GitHub typing, which used generic.

## Test Plan

`yarn lint`, so `tsc` and `eslint` check were successfully.

`yarn test` did not yield any errors.