### PR TITLE
improve readme table formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,19 +34,19 @@ There are some additional features included to make the usage of this action as 
 This action is customizable through variables; they are defined in the [`action.yml`](action.yml).
 Here is a summary of all the variables that you can use and their purpose.
 
-| variable         | default | description                                                                                                  |
-| ---------------- | ------- | ------------------------------------------------------------------------------------------------------------ |
-| `expo-version`   | -       | [Expo CLI](https://github.com/expo/expo-cli) version to install, skips when omitted.                         |
-| `expo-cache`     | `false` | If it should use the [GitHub actions (remote) cache](#using-the-built-in-cache).                             |
-| `expo-cache-key` | -       | An optional custom (remote) cache key. _(**use with caution**)_                                              |
-| `eas-version`    | -       | [EAS CLI](https://github.com/expo/eas-cli) version to install, skips when omitted. (`latest` is recommended) |
-| `eas-cache`      | `false` | If it should use the [GitHub actions (remote) cache](#using-the-built-in-cache).                             |
-| `eas-cache-key`  | -       | An optional custom (remote) cache key. _(**use with caution**)_                                              |
-| `packager`       | `yarn`  | The package manager to use. _(e.g. `npm`)_                                                                   |
-| `token`          | -       | The token of your Expo account _(e.g. [`${{ secrets.EXPO_TOKEN }}`][link-actions-secrets])_                  |
-| `username`       | -       | The username of your Expo account _(e.g. `bycedric`)_                                                        |
-| `password`       | -       | The password of your Expo account _(e.g. [`${{ secrets.EXPO_CLI_PASSWORD }}`][link-actions-secrets])_        |
-| `patch-watchers` | `true`  | If it should [patch the `fs.inotify.` limits](#enospc-errors-on-linux).                                      |
+| variable         | default | description                                                                                                      |
+| ---------------- | :-----: | ---------------------------------------------------------------------------------------------------------------- |
+| `expo-version`   | -       | [Expo CLI](https://github.com/expo/expo-cli) version to install, skips when omitted.                             |
+| `expo-cache`     | `false` | If it should use the [GitHub actions (remote) cache](#using-the-built-in-cache).                                 |
+| `expo-cache-key` | -       | An optional custom (remote) cache key. _(**use with caution**)_                                                  |
+| `eas-version`    | -       | [EAS CLI](https://github.com/expo/eas-cli) version to install, skips when omitted.<br/>(`latest` is recommended) |
+| `eas-cache`      | `false` | If it should use the [GitHub actions (remote) cache](#using-the-built-in-cache).                                 |
+| `eas-cache-key`  | -       | An optional custom (remote) cache key. _(**use with caution**)_                                                  |
+| `packager`       | `yarn`  | The package manager to use.<br/>_(e.g. `npm`)_                                                                   |
+| `token`          | -       | The token of your Expo account.<br/>_(e.g. [`${{ secrets.EXPO_TOKEN }}`][link-actions-secrets])_                 |
+| `username`       | -       | The username of your Expo account.<br/>_(e.g. `bycedric`)_                                                       |
+| `password`       | -       | The password of your Expo account.<br/>_(e.g. [`${{ secrets.EXPO_CLI_PASSWORD }}`][link-actions-secrets])_       |
+| `patch-watchers` | `true`  | If it should [patch the `fs.inotify.` limits](#enospc-errors-on-linux).                                          |
 
 > Never hardcode `expo-token` or `expo-password` in your workflow, use [secrets][link-actions-secrets] to store them.
 


### PR DESCRIPTION
### Linked issue

Those changes should improve the table rendering snd readability in package readme and especially in the action description in GitHub Marketplace:

<img width="734" alt="Screenshot 2021-11-16 at 14 34 43" src="https://user-images.githubusercontent.com/719641/141994993-fcc78b5d-1510-47bf-b5e2-da8f5b450ed2.png">

### Additional context

I'm not able to preview the Readme appearance on the Marketplace, but on GitHub it would look like this (no variables name breaking, no breaks in examples):

<img width="714" alt="Screenshot 2021-11-16 at 14 36 08" src="https://user-images.githubusercontent.com/719641/141995321-4b43d4bc-3422-44e8-af0b-338e17cd7509.png">

