### PR TITLE
chore: hook up Prettier, lint root files, reformat

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,22 +1,16 @@
 module.exports = {
+	ignorePatterns: ['/build/**', 'node_modules/**'],
 	parser: '@typescript-eslint/parser',
-	plugins: [
-		'@typescript-eslint',
-		'jest',
-	],
+	plugins: ['@typescript-eslint', 'jest', 'prettier'],
 	env: {
 		es6: true,
 		'jest/globals': true,
 		node: true,
 	},
-	extends: [
-		'eslint:recommended',
-		'plugin:@typescript-eslint/recommended',
-	],
+	extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
 	rules: {
-		'@typescript-eslint/explicit-member-accessibility': [
-			'error', { 'accessibility': 'no-public' },
-		],
+		'@typescript-eslint/explicit-member-accessibility': ['error', { accessibility: 'no-public' }],
 		'@typescript-eslint/indent': ['error', 'tab'],
+		'prettier/prettier': 'error',
 	},
 };

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,6 @@
   "singleQuote": true,
   "bracketSameLine": true,
   "trailingComma": "es5",
-  "arrowParens": "avoid"
+  "arrowParens": "avoid",
+  "endOfLine": "auto"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,7 +2,7 @@
   "printWidth": 120,
   "tabWidth": 2,
   "singleQuote": true,
-  "jsxBracketSameLine": true,
+  "bracketSameLine": true,
   "trailingComma": "es5",
   "arrowParens": "avoid"
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,6 @@ module.exports = {
 	testMatch: ['**/*.test.ts'],
 	testRunner: 'jest-circus/runner',
 	transform: {
-		'^.+\\.ts$': 'ts-jest'
+		'^.+\\.ts$': 'ts-jest',
 	},
 };

--- a/ncc.js
+++ b/ncc.js
@@ -22,10 +22,10 @@ async function build(file) {
 	const name = path.basename(file, path.extname(file));
 	const dir = path.resolve(BUILD_DIR, name);
 
-	await fs.promises.mkdir(dir, { recursive: true })
+	await fs.promises.mkdir(dir, { recursive: true });
 
 	for (const asset in assets) {
-		await fs.promises.mkdir(path.join(dir, path.dirname(asset)), { recursive: true })
+		await fs.promises.mkdir(path.join(dir, path.dirname(asset)), { recursive: true });
 		await write(path.join(dir, asset), assets[asset].source);
 	}
 
@@ -36,12 +36,12 @@ async function build(file) {
 }
 
 async function main() {
-	const actionPath = path.resolve(__dirname, './src/actions')
+	const actionPath = path.resolve(__dirname, './src/actions');
 	const actionFiles = (await fs.promises.readdir(actionPath, { withFileTypes: true }))
 		.filter(entity => entity.isFile())
 		.map(entity => path.join(ACTION_DIR, entity.name));
 
-	return Promise.all(actionFiles.map(build))
+	return Promise.all(actionFiles.map(build));
 }
 
 main();

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	"homepage": "https://github.com/expo/expo-github-action#readme",
 	"scripts": {
 		"test": "jest",
-		"lint": "tsc --noEmit && eslint ./src ./tests",
+		"lint": "tsc --noEmit && eslint .",
 		"build": "node ncc.js",
 		"clean": "rimraf build",
 		"prepare": "husky install"
@@ -43,9 +43,11 @@
 		"conventional-changelog-conventionalcommits": "^4.6.0",
 		"eslint": "^8.2.0",
 		"eslint-plugin-jest": "^25.2.4",
+		"eslint-plugin-prettier": "^4.0.0",
 		"husky": "^6.0.0",
 		"jest": "^27.3.1",
 		"jest-circus": "^27.3.1",
+		"prettier": "^2.4.1",
 		"rimraf": "^3.0.2",
 		"semantic-release": "^17.4.4",
 		"ts-jest": "^27.0.7",

--- a/src/actions/setup.ts
+++ b/src/actions/setup.ts
@@ -10,21 +10,17 @@ export async function setupAction(): Promise<void> {
 	const expoVersion = await installCli('expo-cli');
 	const easVersion = await installCli('eas-cli');
 
-	await group(
-		'Checking current authenticated account',
-		() => tools.maybeAuthenticate({
+	await group('Checking current authenticated account', () =>
+		tools.maybeAuthenticate({
 			cli: expoVersion ? 'expo-cli' : easVersion ? 'eas-cli' : undefined,
 			token: getInput('token') || undefined,
 			username: getInput('username') || undefined,
 			password: getInput('password') || undefined,
-		}),
+		})
 	);
 
 	if (tools.getBoolean(getInput('patch-watchers'), true)) {
-		await group(
-			'Patching system watchers for the `ENOSPC` error',
-			() => tools.maybePatchWatchers(),
-		);
+		await group('Patching system watchers for the `ENOSPC` error', () => tools.maybePatchWatchers());
 	}
 }
 
@@ -45,11 +41,14 @@ async function installCli(name: tools.PackageName): Promise<string | void> {
 			cache
 				? `Installing ${name} (${version}) from cache or with ${packager}`
 				: `Installing ${name} (${version}) with ${packager}`,
-			() => install({
-				packager, version, cache,
-				package: name,
-				cacheKey: getInput(`${shortName}-cache-key`) || undefined,
-			}),
+			() =>
+				install({
+					packager,
+					version,
+					cache,
+					package: name,
+					cacheKey: getInput(`${shortName}-cache-key`) || undefined,
+				})
 		);
 
 		addPath(path);

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -82,9 +82,7 @@ function getRemoteKey(config: Omit<CacheConfig, 'cacheKey'>): string {
  */
 function handleRemoteCacheError(error: Error): boolean {
 	const isReserveCacheError = error instanceof ReserveCacheError;
-	const isCacheUnavailable = error.message.toLowerCase().includes(
-		'cache service url not found',
-	);
+	const isCacheUnavailable = error.message.toLowerCase().includes('cache service url not found');
 
 	if (isReserveCacheError || isCacheUnavailable) {
 		core.warning('Skipping remote cache storage, encountered error:');

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -51,7 +51,7 @@ export async function maybeAuthenticate(options: AuthenticateOptions = {}): Prom
 				env: { ...process.env, EXPO_TOKEN: options.token },
 			});
 		} else {
-			core.info('Skipping token validation: no CLI installed, can\'t run `whoami`.');
+			core.info("Skipping token validation: no CLI installed, can't run `whoami`.");
 		}
 
 		return core.exportVariable('EXPO_TOKEN', options.token);
@@ -59,7 +59,9 @@ export async function maybeAuthenticate(options: AuthenticateOptions = {}): Prom
 
 	if (options.username || options.password) {
 		if (options.cli !== 'expo-cli') {
-			return core.warning('Skipping authentication: only Expo CLI supports programmatic credentials, use `token` instead.');
+			return core.warning(
+				'Skipping authentication: only Expo CLI supports programmatic credentials, use `token` instead.'
+			);
 		}
 
 		if (!options.username || !options.password) {
@@ -113,7 +115,9 @@ export async function maybeWarnForUpdate(name: PackageName): Promise<void> {
 
 	if (semver.diff(latest, current) === 'major') {
 		core.warning(`There is a new major version available of the Expo CLI (${latest})`);
-		core.warning(`If you run into issues, try upgrading your workflow to "${binaryName}-version: ${semver.major(latest)}.x"`);
+		core.warning(
+			`If you run into issues, try upgrading your workflow to "${binaryName}-version: ${semver.major(latest)}.x"`
+		);
 	}
 }
 

--- a/tests/actions/setup.test.ts
+++ b/tests/actions/setup.test.ts
@@ -62,8 +62,7 @@ describe('run', () => {
 				mockInput({ [`${cliName}Version`]: 'latest' });
 				await setupAction();
 				expect(install.install).toBeCalledWith({
-					package:
-					packageName,
+					package: packageName,
 					version: 'latest',
 					packager: 'yarn',
 					cache: false,
@@ -101,7 +100,7 @@ describe('run', () => {
 					packager: 'yarn',
 					[`${cliName}Version`]: '4.2.0',
 					[`${cliName}Cache`]: 'true',
-					[`${cliName}CacheKey`]: 'custom-key'
+					[`${cliName}CacheKey`]: 'custom-key',
 				});
 				await setupAction();
 				expect(install.install).toBeCalledWith({
@@ -145,7 +144,8 @@ function mockInput(props: MockInputProps = {}) {
 			case 'expo-cache':
 				return props.expoCache || '';
 			case 'expo-cache-key':
-				return props.expoCacheKey || '';``
+				return props.expoCacheKey || '';
+				``;
 			case 'eas-version':
 				return props.easVersion || '';
 			case 'eas-cache':

--- a/tests/actions/setup.test.ts
+++ b/tests/actions/setup.test.ts
@@ -145,7 +145,6 @@ function mockInput(props: MockInputProps = {}) {
 				return props.expoCache || '';
 			case 'expo-cache-key':
 				return props.expoCacheKey || '';
-				``;
 			case 'eas-version':
 				return props.easVersion || '';
 			case 'eas-cache':

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -53,7 +53,7 @@ describe(cache.fromRemoteCache, () => {
 		expect(await cache.fromRemoteCache({ package: 'expo-cli', version: '3.20.1', packager: 'yarn' })).toBeUndefined();
 		expect(remoteCache.restoreCache).toBeCalledWith(
 			[join('cache', 'path', 'expo-cli', '3.20.1', os.arch())],
-			`expo-cli-${process.platform}-${os.arch()}-yarn-3.20.1`,
+			`expo-cli-${process.platform}-${os.arch()}-yarn-3.20.1`
 		);
 	});
 
@@ -68,30 +68,30 @@ describe(cache.fromRemoteCache, () => {
 		).toBeUndefined();
 		expect(remoteCache.restoreCache).toBeCalledWith(
 			[join('cache', 'path', 'eas-cli', '4.2.0', os.arch())],
-			'custom-cache-key',
+			'custom-cache-key'
 		);
 	});
 
 	it('returns path when remote cache exists', async () => {
 		spy.restore.mockResolvedValueOnce(true);
-		expect(
-			await cache.fromRemoteCache({ package: 'expo-cli', version: '3.20.1', packager: 'npm' })
-		).toBe(join('cache', 'path', 'expo-cli', '3.20.1', os.arch()));
+		expect(await cache.fromRemoteCache({ package: 'expo-cli', version: '3.20.1', packager: 'npm' })).toBe(
+			join('cache', 'path', 'expo-cli', '3.20.1', os.arch())
+		);
 	});
 
 	it('fails when remote cache throws', async () => {
 		const error = new Error('Remote cache restore failed');
 		spy.restore.mockRejectedValueOnce(error);
-		await expect(cache.fromRemoteCache({ package: 'eas-cli', version: '3.20.1', packager: 'yarn' })).rejects.toBe(error);
+		await expect(cache.fromRemoteCache({ package: 'eas-cli', version: '3.20.1', packager: 'yarn' })).rejects.toBe(
+			error
+		);
 	});
 
 	it('skips remote cache when unavailable', async () => {
 		// see: https://github.com/actions/toolkit/blob/9167ce1f3a32ad495fc1dbcb574c03c0e013ae53/packages/cache/src/internal/cacheHttpClient.ts#L41
 		const error = new Error('Cache Service Url not found, unable to restore cache.');
 		spy.restore.mockRejectedValueOnce(error);
-		expect(
-			await cache.fromRemoteCache({ package: 'expo-cli', version: '3.20.1', packager: 'yarn' })
-		).toBeUndefined();
+		expect(await cache.fromRemoteCache({ package: 'expo-cli', version: '3.20.1', packager: 'yarn' })).toBeUndefined();
 		expect(spy.warning).toHaveBeenCalledWith(expect.stringContaining('Skipping remote cache'));
 	});
 });
@@ -112,7 +112,9 @@ describe(cache.toRemoteCache, () => {
 	});
 
 	it('saves remote cache with default key', async () => {
-		expect(await cache.toRemoteCache(join('local', 'path'), { package: 'eas-cli', version: '3.20.1', packager: 'npm' })).toBeUndefined();
+		expect(
+			await cache.toRemoteCache(join('local', 'path'), { package: 'eas-cli', version: '3.20.1', packager: 'npm' })
+		).toBeUndefined();
 		expect(remoteCache.saveCache).toBeCalledWith(
 			[join('local', 'path')],
 			`eas-cli-${process.platform}-${os.arch()}-npm-3.20.1`
@@ -120,30 +122,32 @@ describe(cache.toRemoteCache, () => {
 	});
 
 	it('saves remote cache with custom key', async () => {
-		expect(await cache.toRemoteCache(
-			join('local', 'path'),
-			{ package: 'eas-cli', version: '3.20.1', packager: 'yarn', cacheKey: 'custom-cache-key' }
-		)).toBeUndefined();
+		expect(
+			await cache.toRemoteCache(join('local', 'path'), {
+				package: 'eas-cli',
+				version: '3.20.1',
+				packager: 'yarn',
+				cacheKey: 'custom-cache-key',
+			})
+		).toBeUndefined();
 		expect(remoteCache.saveCache).toBeCalledWith([join('local', 'path')], 'custom-cache-key');
 	});
 
 	it('fails when remote cache throws', async () => {
 		const error = new Error('Remote cache save failed');
 		spy.save.mockRejectedValueOnce(error);
-		await expect(cache.toRemoteCache(
-			join('local', 'path'),
-			{ package: 'expo-cli', version: '3.20.1', packager: 'yarn' },
-		)).rejects.toBe(error);
+		await expect(
+			cache.toRemoteCache(join('local', 'path'), { package: 'expo-cli', version: '3.20.1', packager: 'yarn' })
+		).rejects.toBe(error);
 	});
 
 	it('skips remote cache when unavailable', async () => {
 		// see: https://github.com/actions/toolkit/blob/9167ce1f3a32ad495fc1dbcb574c03c0e013ae53/packages/cache/src/internal/cacheHttpClient.ts#L41
 		const error = new Error('Cache Service Url not found, unable to restore cache.');
 		spy.save.mockRejectedValueOnce(error);
-		await expect(cache.toRemoteCache(
-			join('local', 'path'),
-			{ package: 'expo-cli', version: '3.20.1', packager: 'yarn' },
-		)).resolves.toBeUndefined();
+		await expect(
+			cache.toRemoteCache(join('local', 'path'), { package: 'expo-cli', version: '3.20.1', packager: 'yarn' })
+		).resolves.toBeUndefined();
 		expect(spy.warning).toHaveBeenCalledWith(expect.stringContaining('Skipping remote cache'));
 	});
 });

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -29,7 +29,11 @@ describe('install', () => {
 		cache.toLocalCache.mockResolvedValue(join('cache', 'path'));
 		const expoPath = await install.install({ package: 'expo-cli', version: '3.0.10', packager: 'npm' });
 		expect(expoPath).toBe(join('cache', 'path', 'node_modules', '.bin'));
-		expect(cache.toLocalCache).toBeCalledWith(join('temp', 'path'), { package: 'expo-cli', version: '3.0.10', packager: 'npm' });
+		expect(cache.toLocalCache).toBeCalledWith(join('temp', 'path'), {
+			package: 'expo-cli',
+			version: '3.0.10',
+			packager: 'npm',
+		});
 		utils.restoreEnv();
 	});
 
@@ -38,7 +42,12 @@ describe('install', () => {
 		cache.fromRemoteCache.mockResolvedValue(join('cache', 'path'));
 		const expoPath = await install.install({ package: 'eas-cli', version: '4.2.0', packager: 'yarn', cache: true });
 		expect(expoPath).toBe(join('cache', 'path', 'node_modules', '.bin'));
-		expect(cache.fromRemoteCache).toBeCalledWith({ package: 'eas-cli', version: '4.2.0', packager: 'yarn', cache: true });
+		expect(cache.fromRemoteCache).toBeCalledWith({
+			package: 'eas-cli',
+			version: '4.2.0',
+			packager: 'yarn',
+			cache: true,
+		});
 	});
 
 	it('installs path from packager and cache it remotely', async () => {
@@ -48,7 +57,12 @@ describe('install', () => {
 		cache.toLocalCache.mockResolvedValue(join('cache', 'path'));
 		const expoPath = await install.install({ package: 'expo-cli', version: '3.20.1', packager: 'npm', cache: true });
 		expect(expoPath).toBe(join('cache', 'path', 'node_modules', '.bin'));
-		expect(cache.toRemoteCache).toBeCalledWith(join('cache', 'path'), { package: 'expo-cli', version: '3.20.1', packager: 'npm', cache: true });
+		expect(cache.toRemoteCache).toBeCalledWith(join('cache', 'path'), {
+			package: 'expo-cli',
+			version: '3.20.1',
+			packager: 'npm',
+			cache: true,
+		});
 		utils.restoreEnv();
 	});
 });

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -179,7 +179,7 @@ describe(tools.maybeAuthenticate, () => {
 
 		it('executes login command with password through environment', async () => {
 			utils.setEnv('TEST_INCLUDED', 'hellyeah');
-			await tools.maybeAuthenticate({ username, password, cli: 'expo-cli' })
+			await tools.maybeAuthenticate({ username, password, cli: 'expo-cli' });
 			expect(spy.exec).toBeCalled();
 			expect(spy.exec.mock.calls[0][1]).toStrictEqual(['login', `--username=${username}`]);
 			expect(spy.exec.mock.calls[0][2]).toMatchObject({
@@ -194,9 +194,7 @@ describe(tools.maybeAuthenticate, () => {
 		it('fails when credentials are incorrect', async () => {
 			const error = new Error('Invalid username/password. Please try again.');
 			spy.exec.mockRejectedValue(error);
-			await expect(tools.maybeAuthenticate({ username, password, cli: 'expo-cli' }))
-				.rejects
-				.toBe(error);
+			await expect(tools.maybeAuthenticate({ username, password, cli: 'expo-cli' })).rejects.toBe(error);
 		});
 
 		it('executes login command with `expo` on macos', async () => {
@@ -300,21 +298,17 @@ describe(tools.maybeWarnForUpdate, () => {
 	});
 
 	it('is silent when major version is up to date', async () => {
-		registry.manifest
-			.mockResolvedValueOnce({ version: '4.1.0' })
-			.mockResolvedValueOnce({ version: '4.0.1'});
+		registry.manifest.mockResolvedValueOnce({ version: '4.1.0' }).mockResolvedValueOnce({ version: '4.0.1' });
 		await tools.maybeWarnForUpdate('eas-cli');
 		expect(spy.warning).not.toBeCalled();
-	})
+	});
 
 	it('warns when major version is outdated', async () => {
-		registry.manifest
-			.mockResolvedValueOnce({ version: '4.1.0' })
-			.mockResolvedValueOnce({ version: '3.0.1'});
+		registry.manifest.mockResolvedValueOnce({ version: '4.1.0' }).mockResolvedValueOnce({ version: '3.0.1' });
 		await tools.maybeWarnForUpdate('expo-cli');
 		expect(spy.warning).toBeCalledWith('There is a new major version available of the Expo CLI (4.1.0)');
 		expect(spy.warning).toBeCalledWith('If you run into issues, try upgrading your workflow to "expo-version: 4.x"');
-	})
+	});
 });
 
 describe(tools.handleError, () => {

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -38,7 +38,7 @@ export function restoreEnv(): void {
  */
 export function getToolsMock() {
 	return {
-		getBoolean: jest.fn((v, d) => v ? v === 'true' : d),
+		getBoolean: jest.fn((v, d) => (v ? v === 'true' : d)),
 		getBinaryName: jest.fn(v => v.replace('-cli', '')),
 		resolveVersion: jest.fn((n, v) => v),
 		maybeAuthenticate: jest.fn(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2604,6 +2604,13 @@ eslint-plugin-jest@^25.2.4:
   dependencies:
     "@typescript-eslint/experimental-utils" "^5.0.0"
 
+eslint-plugin-prettier@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz#8b99d1e4b8b24a762472b4567992023619cb98e0"
+  integrity sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -2813,6 +2820,11 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^3.1.1:
   version "3.2.5"
@@ -5857,6 +5869,18 @@ prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
+  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
 
 pretty-format@^27.0.0, pretty-format@^27.3.1:
   version "27.3.1"


### PR DESCRIPTION
### Linked issue

It looks like despite the presence of `.prettierrc` file, the Prettier check were not hooked up into lint setup or event present in the project dependencies.

### Additional context

This PR adds the missing dependencies, updates the ESLint config to include the Prettier checks and reformats all the files.

I have also extended the scope of the lint check to the project root (because I saw some mixed whitespaces in files at root level), thats also why I have added the `ignorePatterns` entries in the ESLint config, otherwise the check performance has degraded drstically. 
