### PR TITLE
refactor: enable caches by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Here is a summary of all the variables that you can use and their purpose.
 | variable         | default | description                                                                          |
 | ---------------- | ------- | ------------------------------------------------------------------------------------ |
 | `expo-version`   | `''`    | [Expo CLI](https://github.com/expo/expo-cli) version to install, skips when omitted. |
-| `expo-cache`     | `false` | If it should use the [GitHub actions cache](#using-the-built-in-cache).     |
+| `expo-cache`     | `true`  | If it should use the [GitHub actions cache](#using-the-built-in-cache).              |
 | `eas-version`    | `''`    | [EAS CLI](https://github.com/expo/eas-cli) version to install, skips when omitted.   |
-| `eas-cache`      | `false` | If it should use the [GitHub actions cache](#using-the-built-in-cache).     |
+| `eas-cache`      | `true`  | If it should use the [GitHub actions cache](#using-the-built-in-cache).              |
 | `packager`       | `yarn`  | The package manager to use. _(e.g. `yarn` or `npm`)_                                 |
 | `token`          | `''`    | The token of your Expo account                                                       |
 | `patch-watchers` | `true`  | If it should [patch the `fs.inotify.` limits](#enospc-errors-on-linux).              |
@@ -190,9 +190,9 @@ This action can export the `EXPO_TOKEN` variable to access it in every step.
 
 ### Using the built-in cache
 
-You can opt-in to caching the installation, making it a lot faster.
-Under the hood, it uses the [`@actions/cache`][link-actions-cache-package] package to restore the Expo CLI installation.
-This action generates a unique cache key for the OS, used packager, and exact version of the Expo CLI.
+Caching is enabled by default to speed up consecutive CLI installs, but you can still opt-out to this.
+Under the hood, it uses the [`@actions/cache`][link-actions-cache-package] package to restore the CLI installation.
+This action generates a unique cache key for the OS, used packager, and exact version of the CLI.
 
 > Note, this cache will count towards your [repo cache limit][link-actions-cache-limit]. The Expo and EAS CLI are stored in different caches.
 

--- a/action.yml
+++ b/action.yml
@@ -13,12 +13,12 @@ inputs:
     description: Expo CLI version to install
   expo-cache:
     description: If Expo CLI should be cached to speed up installation
-    default: false
+    default: true
   eas-version:
     description: EAS CLI version to install
   eas-cache:
     description: If EAS CLI should be cached to speed up installation
-    default: false
+    default: true
   packager:
     description: The package manager used to install the CLIs
     default: yarn

--- a/build/setup/index.js
+++ b/build/setup/index.js
@@ -65134,9 +65134,9 @@ const worker_1 = __nccwpck_require__(8912);
 (0, worker_1.executeAction)(setupAction);
 function setupInput() {
     return {
-        easCache: (0, core_1.getBooleanInput)('eas-cache'),
+        easCache: !(0, core_1.getInput)('eas-cache') || (0, core_1.getBooleanInput)('eas-cache'),
         easVersion: (0, core_1.getInput)('eas-version'),
-        expoCache: (0, core_1.getBooleanInput)('expo-cache'),
+        expoCache: !(0, core_1.getInput)('expo-cache') || (0, core_1.getBooleanInput)('expo-cache'),
         expoVersion: (0, core_1.getInput)('expo-version'),
         packager: (0, core_1.getInput)('packager') || 'yarn',
         patchWatchers: !(0, core_1.getInput)('patch-watchers') || (0, core_1.getBooleanInput)('patch-watchers'),

--- a/src/actions/setup.ts
+++ b/src/actions/setup.ts
@@ -11,9 +11,9 @@ export type SetupInput = ReturnType<typeof setupInput>;
 
 export function setupInput() {
   return {
-    easCache: getBooleanInput('eas-cache'),
+    easCache: !getInput('eas-cache') || getBooleanInput('eas-cache'),
     easVersion: getInput('eas-version'),
-    expoCache: getBooleanInput('expo-cache'),
+    expoCache: !getInput('expo-cache') || getBooleanInput('expo-cache'),
     expoVersion: getInput('expo-version'),
     packager: getInput('packager') || 'yarn',
     patchWatchers: !getInput('patch-watchers') || getBooleanInput('patch-watchers'),

--- a/tests/actions/setup.test.ts
+++ b/tests/actions/setup.test.ts
@@ -14,9 +14,9 @@ jest.mock('../../src/worker');
 describe(setupInput, () => {
   it('returns object with correct defaults', () => {
     expect(setupInput()).toMatchObject({
-      easCache: undefined,
+      easCache: true,
       easVersion: undefined,
-      expoCache: undefined,
+      expoCache: true,
       expoVersion: undefined,
       packager: 'yarn',
       patchWatchers: true,
@@ -72,7 +72,7 @@ describe(setupAction, () => {
 
     it(`installs ${cliName} using npm`, async () => {
       jest.mocked(packager.resolvePackage).mockResolvedValue('5.0.3');
-      await setupAction({ ...input, [cliVersion]: '5.x', packager: 'npm' });
+      await setupAction({ ...input, [cliVersion]: '5.x', [cliCache]: false, packager: 'npm' });
       expect(packager.installPackage).toBeCalledWith(cliName, '5.0.3', 'npm');
       expect(worker.installToolFromPackage).toBeCalled();
     });


### PR DESCRIPTION
### Linked issue
The caches were an experimental feature when added, and required a fork of the `@actions/cache` library. But, the original `@actions/cache` supports it, we can enable this by default. You can still opt-out from using a cache. 