### PR TITLE
refactor(preview-comment): auto-fill the github token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
             const message = `${{ steps.preview.outputs.message }}`
             if (!message) throw new Error('Message output is empty')
       
-      - name: 🧪 Comment on PR (input auth)
+      - name: 🧪 Comment on PR (github-token)
         uses: ./preview-comment
         env:
           EXPO_TEST_GITHUB_PULL: 149
@@ -87,7 +87,7 @@ jobs:
           project: ./temp
           channel: test
 
-      - name: 🧪 Comment on PR (envvar auth)
+      - name: 🧪 Comment on PR (GITHUB_TOKEN)
         uses: ./preview-comment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -95,6 +95,6 @@ jobs:
         with:
           project: ./temp
           channel: test
-          github-token: ''
+          github-token: badtoken
 
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
     - cron: '0 15 * * *'
   push:
     branches: [main]
+  pull_request:
+    types: [opened, synchronize]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,8 +76,16 @@ jobs:
           script: |
             const message = `${{ steps.preview.outputs.message }}`
             if (!message) throw new Error('Message output is empty')
+      
+      - name: 🧪 Comment on PR (input auth)
+        uses: ./preview-comment
+        env:
+          EXPO_TEST_GITHUB_PULL: 149
+        with:
+          project: ./temp
+          channel: test
 
-      - name: 🧪 Comment on PR
+      - name: 🧪 Comment on PR (envvar auth)
         uses: ./preview-comment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -85,5 +93,6 @@ jobs:
         with:
           project: ./temp
           channel: test
+          github-token: ''
 
 

--- a/README.md
+++ b/README.md
@@ -170,8 +170,6 @@ jobs:
 
       - name: 💬 Comment preview
         uses: expo/expo-github-action/preview-comment@v7
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           channel: pr-${{ github.event.number }}
 ```

--- a/preview-comment/README.md
+++ b/preview-comment/README.md
@@ -44,6 +44,7 @@ Here is a summary of all the input options you can use.
 | **comment**    | `true`                      | If this action should comment on a PR                                                            |
 | **message**    | _[see code][code-defaults]_ | The message template                                                                             |
 | **message-id** | _[see code][code-defaults]_ | A unique id template to prevent duplicate comments ([read more](#preventing-duplicate-comments)) |
+| **github-token** | `GITHUB_TOKEN` | A GitHub token to use when commenting on PR ([read more](#github-tokens)) |
 
 ## Available outputs
 
@@ -107,8 +108,6 @@ jobs:
 
       - name: 💬 Comment in preview
         uses: expo/expo-github-action/preview-comment@v7
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           channel: pr-${{ github.event.number }}
 ```
@@ -173,6 +172,12 @@ jobs:
 When automating these preview comments, you have to be careful not to spam a pull request on every successful run. 
 Every comment contains a generated **message-id** to identify previously made comments and update instead of creating a new comment.
 
+### GitHub tokens
+
+When using the GitHub API, you always need to be authenticated.
+This action tries to auto-authenticate using the [Automatic token authentication][link-gha-token] from GitHub.
+You can overwrite the token by adding the `GITHUB_TOKEN` environment variable, or add the **github-token** input.
+
 <div align="center">
   <br />
   with :heart:&nbsp;<strong>byCedric</strong>
@@ -181,3 +186,4 @@ Every comment contains a generated **message-id** to identify previously made co
 
 [code-defaults]: ../src/actions/preview-comment.ts
 [link-actions]: https://help.github.com/en/categories/automating-your-workflow-with-github-actions
+[link-gha-token]: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

--- a/preview-comment/action.yml
+++ b/preview-comment/action.yml
@@ -25,6 +25,10 @@ inputs:
   message-id:
     description: A unique identifier to prevent multiple comments on the same pull request
     required: false
+  github-token:
+    description: GitHub access token to comment on PRs
+    required: false
+    default: ${{ github.token }}
 outputs:
   projectOwner:
     description: The resolved project owner

--- a/src/actions/preview-comment.ts
+++ b/src/actions/preview-comment.ts
@@ -20,6 +20,7 @@ export function commentInput() {
     message: getInput('message') || DEFAULT_MESSAGE,
     messageId: getInput('message-id') || DEFAULT_ID,
     project: getInput('project'),
+    githubToken: getInput('github-token'),
   };
 }
 
@@ -46,7 +47,9 @@ export async function commentAction(input: CommentInput = commentInput()) {
   if (!input.comment) {
     info(`Skipped comment: 'comment' is disabled`);
   } else {
-    await createIssueComment(pullContext(), {
+    await createIssueComment({
+      ...pullContext(),
+      token: input.githubToken,
       id: messageId,
       body: messageBody,
     });

--- a/tests/actions/preview-comment.test.ts
+++ b/tests/actions/preview-comment.test.ts
@@ -24,6 +24,7 @@ describe(commentInput, () => {
       message: DEFAULT_MESSAGE,
       messageId: DEFAULT_ID,
       project: undefined,
+      githubToken: undefined,
     });
   });
 
@@ -46,6 +47,11 @@ describe(commentInput, () => {
     mockInput({ channel: 'pr-420' });
     expect(commentInput()).toMatchObject({ channel: 'pr-420' });
   });
+
+  it('returns github-token', () => {
+    mockInput({ 'github-token': 'fakegithubtoken' });
+    expect(commentInput()).toMatchObject({ githubToken: 'fakegithubtoken' });
+  });
 });
 
 describe(commentAction, () => {
@@ -55,6 +61,7 @@ describe(commentAction, () => {
     message: DEFAULT_MESSAGE,
     messageId: DEFAULT_ID,
     project: '',
+    githubToken: '',
   };
 
   beforeEach(() => {

--- a/tests/github.test.ts
+++ b/tests/github.test.ts
@@ -8,16 +8,32 @@ jest.mock('@actions/github');
 describe(githubApi, () => {
   afterEach(resetEnv);
 
-  it('throws when GITHUB_TOKEN is undefined', () => {
+  it('throws when GITHUB_TOKEN and input are undefined', () => {
     setEnv('GITHUB_TOKEN', '');
-    expect(() => githubApi()).toThrow(`requires a GITHUB_TOKEN`);
+    expect(() => githubApi()).toThrow(`requires 'github-token' or a GITHUB_TOKEN`);
   });
 
-  it('returns an octokit instance', () => {
+  it('returns octokit instance with GITHUB_TOKEN', () => {
     setEnv('GITHUB_TOKEN', 'fakegithubtoken');
     const fakeGithub = {};
     jest.mocked(github.getOctokit).mockReturnValue(fakeGithub as any);
     expect(githubApi()).toBe(fakeGithub);
+    expect(github.getOctokit).toBeCalledWith('fakegithubtoken');
+  });
+
+  it('returns octokit instance with input', () => {
+    setEnv('GITHUB_TOKEN', '');
+    const fakeGithub = {};
+    jest.mocked(github.getOctokit).mockReturnValue(fakeGithub as any);
+    expect(githubApi({ token: 'fakegithubtoken' })).toBe(fakeGithub);
+    expect(github.getOctokit).toBeCalledWith('fakegithubtoken');
+  });
+
+  it('uses GITHUB_TOKEN before input', () => {
+    setEnv('GITHUB_TOKEN', 'fakegithubtoken');
+    const fakeGithub = {};
+    jest.mocked(github.getOctokit).mockReturnValue(fakeGithub as any);
+    expect(githubApi({ token: 'badfakegithubtoken' })).toBe(fakeGithub);
     expect(github.getOctokit).toBeCalledWith('fakegithubtoken');
   });
 });


### PR DESCRIPTION
### Linked issue
This change allows the preview-action to inehrit the token from the current run. It does that by setting a default value for `github-token` to `${{ github.token }}`.

This would make it way easier to set previews up, by not thinking about that token at all. But, it's a bit more "intrusive" compared to the previous way.