### PR TITLE
fix: output error stacktraces in debug mode

### DIFF
--- a/build/preview-comment/index.js
+++ b/build/preview-comment/index.js
@@ -16021,9 +16021,16 @@ Object.defineProperty(exports, "findTool", ({ enumerable: true, get: function ()
 Object.defineProperty(exports, "cacheTool", ({ enumerable: true, get: function () { return tool_cache_1.cacheDir; } }));
 /**
  * Auto-execute the action and pass errors to 'core.setFailed'.
+ * It also passes the full error, with stacktrace, to 'core.debug'.
+ * You'll need to enable debugging to view these full errors.
+ *
+ * @see https://github.com/actions/toolkit/blob/main/docs/action-debugging.md#step-debug-logs
  */
-async function executeAction(action) {
-    return action().catch(error => (0, core_1.setFailed)(error.message || error));
+function executeAction(action) {
+    return action().catch((error) => {
+        (0, core_1.setFailed)(error.message || error);
+        (0, core_1.debug)(error.stack || 'No stacktrace available');
+    });
 }
 exports.executeAction = executeAction;
 /**

--- a/build/setup/index.js
+++ b/build/setup/index.js
@@ -67067,9 +67067,16 @@ Object.defineProperty(exports, "findTool", ({ enumerable: true, get: function ()
 Object.defineProperty(exports, "cacheTool", ({ enumerable: true, get: function () { return tool_cache_1.cacheDir; } }));
 /**
  * Auto-execute the action and pass errors to 'core.setFailed'.
+ * It also passes the full error, with stacktrace, to 'core.debug'.
+ * You'll need to enable debugging to view these full errors.
+ *
+ * @see https://github.com/actions/toolkit/blob/main/docs/action-debugging.md#step-debug-logs
  */
-async function executeAction(action) {
-    return action().catch(error => (0, core_1.setFailed)(error.message || error));
+function executeAction(action) {
+    return action().catch((error) => {
+        (0, core_1.setFailed)(error.message || error);
+        (0, core_1.debug)(error.stack || 'No stacktrace available');
+    });
 }
 exports.executeAction = executeAction;
 /**

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,4 +1,4 @@
-import { addPath, info, setFailed, warning } from '@actions/core';
+import { addPath, debug, info, setFailed, warning } from '@actions/core';
 import { exec } from '@actions/exec';
 import { ok as assert } from 'assert';
 import os from 'os';
@@ -8,9 +8,16 @@ export { find as findTool, cacheDir as cacheTool } from '@actions/tool-cache';
 
 /**
  * Auto-execute the action and pass errors to 'core.setFailed'.
+ * It also passes the full error, with stacktrace, to 'core.debug'.
+ * You'll need to enable debugging to view these full errors.
+ *
+ * @see https://github.com/actions/toolkit/blob/main/docs/action-debugging.md#step-debug-logs
  */
-export async function executeAction(action: () => Promise<void>) {
-  return action().catch(error => setFailed(error.message || error));
+export function executeAction(action: () => Promise<void>) {
+  return action().catch((error: Error) => {
+    setFailed(error.message || error);
+    debug(error.stack || 'No stacktrace available');
+  });
 }
 
 /**

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -92,4 +92,19 @@ describe(executeAction, () => {
     await expect(executeAction(action)).resolves.not.toThrow();
     expect(core.setFailed).toBeCalledWith(error.message);
   });
+
+  it('provides full stacktrace to debug', async () => {
+    const error = new Error('fake error');
+    const action = jest.fn(() => Promise.reject(error));
+    await expect(executeAction(action)).resolves.not.toThrow();
+    expect(core.debug).toBeCalledWith(error.stack);
+  });
+
+  it('provides fallback stacktrace to debug', async () => {
+    const error = new Error('fake error');
+    error.stack = undefined;
+    const action = jest.fn(() => Promise.reject(error));
+    await expect(executeAction(action)).resolves.not.toThrow();
+    expect(core.debug).toBeCalledWith('No stacktrace available');
+  });
 });


### PR DESCRIPTION
### Linked issue
Follow-up of #159

### Additional context
This would make stack traces available through Github actions debugging. https://github.com/actions/toolkit/blob/main/docs/action-debugging.md#step-debug-logs
