### PR TITLE
chore: always dry run a new release on merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: release
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       release:


### PR DESCRIPTION
### Linked issue
On every PR merge or main push, run a test release to preview the expected version