### PR TITLE
fix: package tool escape path on windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,12 @@ jobs:
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v2
+        
+      - name: TEST Windows packager resolve stuff
+        uses: actions/github-script@v5
+        with:
+          script: |
+            console.log(await io.which('npm'));
 
       - name: 🏗 Setup Expo
         uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,22 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
+          - macos-latest
         cache:
           - with-cache
           - without-cache
+        packager:
+          - yarn
+        include:
+          - os: ubuntu-latest
+            cache: without-cache
+            packager: npm
+          - os: windows-latest
+            cache: without-cache
+            packager: npm
+          - os: macos-latest
+            cache: without-cache
+            packager: npm
     runs-on: ${{ matrix.os }}
     steps:
       - name: 🏗 Setup repo
@@ -38,6 +51,7 @@ jobs:
           eas-cache: ${{ matrix.cache == 'with-cache' }}
           expo-version: latest
           expo-cache: ${{ matrix.cache == 'with-cache' }}
+          packager: ${{ matrix.packager }}
           token: ${{ secrets.EXPO_TOKEN }}
       
       - name: 🧪 EAS installed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,9 @@ jobs:
         uses: actions/github-script@v5
         with:
           script: |
-            console.log(await io.which('npm'));
+            const cliPath = await io.which('npm');
+            const output = await exec.getExecOutput('npm', ['--version']);
+            console.log({ cliPath, output });
 
       - name: 🏗 Setup Expo
         uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,18 +43,6 @@ jobs:
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v2
-        
-      - name: TEST Windows packager resolve stuff
-        uses: actions/github-script@v5
-        with:
-          script: |
-            const path = require('path');
-            const cliPath = await io.which('npm');
-            const output = await exec.getExecOutput(cliPath, ['--version']);
-            console.log({ cliPath, output });
-            const tempPath = path.join(process.env['RUNNER_TEMP'], 'abc');
-            await io.mkdirP(tempPath);
-            await exec.exec(cliPath, ['--version'], { cwd: tempPath });
 
       - name: 🏗 Setup Expo
         uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,9 +48,13 @@ jobs:
         uses: actions/github-script@v5
         with:
           script: |
+            const path = require('path');
             const cliPath = await io.which('npm');
-            const output = await exec.getExecOutput('npm', ['--version']);
+            const output = await exec.getExecOutput(cliPath, ['--version']);
             console.log({ cliPath, output });
+            const tempPath = path.join(process.env['RUNNER_TEMP'], 'abc');
+            await io.mkdirP(tempPath);
+            await exec.exec(cliPath, ['--version'], { cwd: tempPath });
 
       - name: 🏗 Setup Expo
         uses: ./

--- a/build/setup/index.js
+++ b/build/setup/index.js
@@ -67049,9 +67049,8 @@ exports.resolvePackage = resolvePackage;
  */
 async function installPackage(name, version, manager) {
     const temp = (0, worker_1.tempPath)(name, version);
-    const tool = await (0, io_1.which)(manager);
     await (0, io_1.mkdirP)(temp);
-    await (0, exec_1.exec)(tool, ['add', `${name}@${version}`], { cwd: temp });
+    await (0, exec_1.exec)(manager, ['add', `${name}@${version}`], { cwd: temp });
     return (0, worker_1.cacheTool)(temp, name, version);
 }
 exports.installPackage = installPackage;

--- a/src/packager.ts
+++ b/src/packager.ts
@@ -1,5 +1,5 @@
 import { exec, getExecOutput } from '@actions/exec';
-import { which, mkdirP } from '@actions/io';
+import { mkdirP } from '@actions/io';
 
 import { cacheTool, tempPath } from './worker';
 
@@ -37,10 +37,9 @@ export async function resolvePackage(name: string, range: string): Promise<strin
  */
 export async function installPackage(name: string, version: string, manager: string) {
   const temp = tempPath(name, version);
-  const tool = await which(manager);
 
   await mkdirP(temp);
-  await exec(tool, ['add', `${name}@${version}`], { cwd: temp });
+  await exec(manager, ['add', `${name}@${version}`], { cwd: temp });
 
   return cacheTool(temp, name, version);
 }


### PR DESCRIPTION
### Linked issue
See #167

### Additional context
This should also add more visibility if something is going wrong on OS or with npm/yarn, like #167.
