### PR TITLE
docs(preview-comment): add missing permissions in examples

### DIFF
--- a/preview-comment/README.md
+++ b/preview-comment/README.md
@@ -85,6 +85,8 @@ on:
 jobs:
   preview:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # Allow comments on PRs
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v2
@@ -128,6 +130,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # Allow comments on PRs
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v2


### PR DESCRIPTION
### Linked issue
With GH being more restrictive in some repos, always declaring the permission might be better.