### PR TITLE
refactor: drop rimraf dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "jest",
     "lint": "eslint .",
     "build": "node ncc.js",
-    "clean": "rimraf build"
+    "clean": "git clean -xdf ./build"
   },
   "dependencies": {
     "@actions/cache": "^3.1.2",
@@ -43,7 +43,6 @@
     "eslint-config-universe": "^10.0.0",
     "jest": "^27.4.7",
     "prettier": "^2.5.1",
-    "rimraf": "^3.0.2",
     "semantic-release": "^19.0.3",
     "ts-jest": "^27.1.2",
     "typescript": "^4.5.4"


### PR DESCRIPTION
### Linked issue
Let's use git to clean out the build files.