### PR TITLE
Updates the example in the README to use eas-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ jobs:
       - name: 🏗 Setup EAS
         uses: expo/expo-github-action@v8
         with:
-          expo-version: latest
+          eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: 📦 Install dependencies


### PR DESCRIPTION
I tried out the code in the README and got hung up on the fact that EAS CLI was not installed. I was not installed because the README had an example with `expo-version` instead of `eas-version`. This PR updates that key.