### PR TITLE
docs: add content read permission throughout

### DIFF
--- a/command/README.md
+++ b/command/README.md
@@ -66,6 +66,7 @@ jobs:
     if: ${{ github.event.issue.pull_request }}
     # Allow the bot to comment on pulls
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - name: 🏗 Setup repo

--- a/preview-comment/README.md
+++ b/preview-comment/README.md
@@ -96,6 +96,7 @@ jobs:
   preview:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write # Allow comments on PRs
     steps:
       - name: 🏗 Setup repo
@@ -141,6 +142,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write # Allow comments on PRs
     steps:
       - name: 🏗 Setup repo

--- a/preview/README.md
+++ b/preview/README.md
@@ -130,6 +130,7 @@ jobs:
   preview:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write # Allow comments on PRs
     steps:
       - name: 🏗 Setup repo


### PR DESCRIPTION
### Linked issue

N/A

### Additional context

If you don't provide `contents: read` permissions to workflows in private repos, you get an error during the checkout step:

```
Run actions/checkout@v3
Syncing repository: my-org/my-project
Getting Git version info
Temporarily overriding HOME='/home/runner/work/_temp/ed4d6daf-bb4f-470c-ba2f-679057aaa272' before making global git config changes
Adding repository directory to the temporary git global config as a safe directory
/usr/bin/git config --global --add safe.directory /home/runner/work/my-project/my-project
Deleting the contents of '/home/runner/work/my-project/my-project'
Initializing the repository
Disabling automatic garbage collection
Setting up auth
Fetching the repository
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +9c37bea72cec39780111e301366f3974fa729e42:refs/remotes/pull/26/merge
  remote: Repository not found.
  Error: fatal: repository 'https://github.com/my-org/my-project/' not found
  The process '/usr/bin/git' failed with exit code 128
  Waiting 17 seconds before trying again
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +9c37bea72cec39780111e301366f3974fa729e42:refs/remotes/pull/26/merge
  remote: Repository not found.
  Error: fatal: repository 'https://github.com/my-org/my-project/' not found
  The process '/usr/bin/git' failed with exit code 128
  Waiting 15 seconds before trying again
  /usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +9c37bea72cec39780111e301366f3974fa729e42:refs/remotes/pull/26/merge
  remote: Repository not found.
  Error: fatal: repository 'https://github.com/my-org/my-project/' not found
  Error: The process '/usr/bin/git' failed with exit code 128
```

For public repos, since the repo is open to the world, this permission isn't required (but it doesn't hurt to add the permission).

For the best developer experience, I think it makes sense to add this permission throughout the docs.