### PR TITLE
fix(preview): filter slugs with special characters to match dev clients `exp+<slug>` scheme

### DIFF
--- a/build/preview/index.js
+++ b/build/preview/index.js
@@ -42133,7 +42133,8 @@ function getUpdateGroupQr({ projectId, updateGroupId, appSlug, qrTarget, }) {
     if (qrTarget === 'dev-build') {
         // While the parameter is called `appScheme`, it's actually the app's slug
         // This should only be added when using dev clients as target
-        url.searchParams.append('appScheme', appSlug);
+        // See: https://github.com/expo/expo/blob/8ae75dde393e5d2393d446227a1fe2482c75eec3/packages/expo-dev-client/plugin/src/getDefaultScheme.ts#L17
+        url.searchParams.append('appScheme', appSlug.replace(/[^A-Za-z0-9+\-.]/g, ''));
     }
     url.searchParams.append('projectId', projectId);
     url.searchParams.append('groupId', updateGroupId);

--- a/src/eas.ts
+++ b/src/eas.ts
@@ -84,7 +84,8 @@ export function getUpdateGroupQr({
   if (qrTarget === 'dev-build') {
     // While the parameter is called `appScheme`, it's actually the app's slug
     // This should only be added when using dev clients as target
-    url.searchParams.append('appScheme', appSlug);
+    // See: https://github.com/expo/expo/blob/8ae75dde393e5d2393d446227a1fe2482c75eec3/packages/expo-dev-client/plugin/src/getDefaultScheme.ts#L17
+    url.searchParams.append('appScheme', appSlug.replace(/[^A-Za-z0-9+\-.]/g, ''));
   }
 
   url.searchParams.append('projectId', projectId);

--- a/tests/eas.test.ts
+++ b/tests/eas.test.ts
@@ -1,0 +1,36 @@
+import { getUpdateGroupQr } from '../src/eas';
+
+describe(getUpdateGroupQr, () => {
+  it('returns url for expo-go', () => {
+    expect(
+      getUpdateGroupQr({
+        qrTarget: 'expo-go',
+        projectId: 'projectId',
+        updateGroupId: 'updateGroupId',
+        appSlug: 'appslug',
+      })
+    ).toBe('https://qr.expo.dev/eas-update?projectId=projectId&groupId=updateGroupId');
+  });
+
+  it('returns url for dev-build', () => {
+    expect(
+      getUpdateGroupQr({
+        qrTarget: 'dev-build',
+        projectId: 'projectId',
+        updateGroupId: 'updateGroupId',
+        appSlug: 'appslug',
+      })
+    ).toBe('https://qr.expo.dev/eas-update?appScheme=appslug&projectId=projectId&groupId=updateGroupId');
+  });
+
+  it('returns url for dev-build, with `_` in appSlug', () => {
+    expect(
+      getUpdateGroupQr({
+        qrTarget: 'dev-build',
+        projectId: 'projectId',
+        updateGroupId: 'updateGroupId',
+        appSlug: 'hello_world',
+      })
+    ).toBe('https://qr.expo.dev/eas-update?appScheme=helloworld&projectId=projectId&groupId=updateGroupId');
+  });
+});


### PR DESCRIPTION
### Linked issue
Fixes #251 

### Additional context
Use the same filtering of slugs, as [done in the `expo-dev-client` plugin here](https://github.com/expo/expo/blob/8ae75dde393e5d2393d446227a1fe2482c75eec3/packages/expo-dev-client/plugin/src/getDefaultScheme.ts#L17).