### PR TITLE
Fix fingerprint action reference in example PR Labeler

### DIFF
--- a/fingerprint/README.md
+++ b/fingerprint/README.md
@@ -119,6 +119,8 @@ jobs:
       pull-requests: write # Allow comments on PRs
       # REQUIRED: Allow updating fingerprint in acton caches
       actions: write
+      # OPTIONAL: Allow reading of repo contents for private projects
+      # contents: read
 
     steps:
       - name: 🏗 Setup repo
@@ -135,7 +137,7 @@ jobs:
 
       - name: Check fingerprint
         id: fingerprint
-        uses: expo/expo-github-action/preview-build@main
+        uses: expo/expo-github-action/fingerprint@main
 
       - uses: actions/github-script@v6
         if: ${{ github.event_name == 'pull_request' && steps.fingerprint.outputs.fingerprint-diff == '[]' }}


### PR DESCRIPTION
Fixes the reference to the fingerprint action in the example PR labeler workflow and add optional content read permission required for the fingerprint action to work private repos with the built-in `GITHUB_TOKEN`

### Linked issue
N/A

### Additional context
N/A
