### PR TITLE
[fingerprint] add previous and current git commit to outputs

### DIFF
--- a/build/fingerprint/index.js
+++ b/build/fingerprint/index.js
@@ -91618,6 +91618,8 @@ async function runAction(input = (0, fingerprint_1.collectFingerprintActionInput
     });
     (0, core_1.setOutput)('previous-fingerprint', previousFingerprint);
     (0, core_1.setOutput)('current-fingerprint', currentFingerprint);
+    (0, core_1.setOutput)('previous-git-commit', input.previousGitCommitHash);
+    (0, core_1.setOutput)('current-git-commit', input.currentGitCommitHash);
     (0, core_1.setOutput)('fingerprint-diff', diff);
 }
 exports.runAction = runAction;

--- a/fingerprint/README.md
+++ b/fingerprint/README.md
@@ -93,6 +93,8 @@ In case you want to reuse this action for other purpose, this action will set th
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **previous-fingerprint** | The fingerprint of the base commit if it has been computed previously. May be null if it has not been computed previously.                                                                    |
 | **current-fingerprint**  | The fingerprint of the current commit.                                                                                                                                                        |
+| **previous-git-commit**  | The Git hash for the base commit.                                                                                                                                                             |
+| **current-git-commit**   | The Git hash for the current commit.                                                                                                                                                          |
 | **fingerprint-diff**     | The diff between the current and the previous fingerprint. It is a JSON array of fingerprint diff. If the fingerprint does not change in between, the result diff will be an empty array `[]` |
 
 ## Example workflows

--- a/fingerprint/action.yml
+++ b/fingerprint/action.yml
@@ -39,5 +39,9 @@ outputs:
     description: The fingerprint of the previous commit. May be null if it has never previously been computed
   current-fingerprint:
     description: The fingerprint of the current commit
+  previous-git-commit:
+    description: The Git hash for the base commit
+  current-git-commit:
+    description: The Git hash for the current commit
   fingerprint-diff:
     description: The diff between the current and the previous fingerprint

--- a/src/actions/fingerprint.ts
+++ b/src/actions/fingerprint.ts
@@ -18,5 +18,7 @@ export async function runAction(input = collectFingerprintActionInput()) {
 
   setOutput('previous-fingerprint', previousFingerprint);
   setOutput('current-fingerprint', currentFingerprint);
+  setOutput('previous-git-commit', input.previousGitCommitHash);
+  setOutput('current-git-commit', input.currentGitCommitHash);
   setOutput('fingerprint-diff', diff);
 }


### PR DESCRIPTION
# Why

to troubleshooting fingerprint action

# How

add the `previous-git-commit` and `current-git-commit` to outputs