### PR TITLE
[fingerprint] support customized input previous-git-commit

### DIFF
--- a/build/fingerprint-post/index.js
+++ b/build/fingerprint-post/index.js
@@ -89107,11 +89107,11 @@ const io_1 = __nccwpck_require__(7436);
 const assert_1 = __importDefault(__nccwpck_require__(9491));
 const fs_1 = __importDefault(__nccwpck_require__(7147));
 const path_1 = __importDefault(__nccwpck_require__(1017));
-const FingerprintDbManager_1 = __nccwpck_require__(7070);
 const cacher_1 = __nccwpck_require__(331);
 const packager_1 = __nccwpck_require__(6466);
 const sqlite_1 = __nccwpck_require__(280);
 const worker_1 = __nccwpck_require__(8912);
+const FingerprintDbManager_1 = __nccwpck_require__(7070);
 __exportStar(__nccwpck_require__(7070), exports);
 /**
  * Shared logic to create a fingerprint diff for fingerprint actions
@@ -89163,10 +89163,12 @@ function collectFingerprintActionInput() {
         fingerprintVersion: (0, core_1.getInput)('fingerprint-version') || 'latest',
         fingerprintInstallationCache: !(0, core_1.getInput)('fingerprint-installation-cache') || (0, core_1.getBooleanInput)('fingerprint-installation-cache'),
         fingerprintDbCacheKey: (0, core_1.getInput)('fingerprint-db-cache-key'),
-        previousGitCommitHash: github_1.context.eventName === 'pull_request'
-            ? github_1.context.payload.pull_request?.base?.sha
-            : github_1.context.payload.before,
-        currentGitCommitHash: github_1.context.eventName === 'pull_request' ? github_1.context.payload.pull_request?.head?.sha : github_1.context.sha,
+        previousGitCommitHash: (0, core_1.getInput)('previous-git-commit') ||
+            (github_1.context.eventName === 'pull_request'
+                ? github_1.context.payload.pull_request?.base?.sha
+                : github_1.context.payload.before),
+        currentGitCommitHash: (0, core_1.getInput)('current-git-commit') ||
+            (github_1.context.eventName === 'pull_request' ? github_1.context.payload.pull_request?.head?.sha : github_1.context.sha),
     };
 }
 exports.collectFingerprintActionInput = collectFingerprintActionInput;

--- a/build/fingerprint-post/index.js
+++ b/build/fingerprint-post/index.js
@@ -89107,11 +89107,11 @@ const io_1 = __nccwpck_require__(7436);
 const assert_1 = __importDefault(__nccwpck_require__(9491));
 const fs_1 = __importDefault(__nccwpck_require__(7147));
 const path_1 = __importDefault(__nccwpck_require__(1017));
+const FingerprintDbManager_1 = __nccwpck_require__(7070);
 const cacher_1 = __nccwpck_require__(331);
 const packager_1 = __nccwpck_require__(6466);
 const sqlite_1 = __nccwpck_require__(280);
 const worker_1 = __nccwpck_require__(8912);
-const FingerprintDbManager_1 = __nccwpck_require__(7070);
 __exportStar(__nccwpck_require__(7070), exports);
 /**
  * Shared logic to create a fingerprint diff for fingerprint actions

--- a/build/fingerprint/index.js
+++ b/build/fingerprint/index.js
@@ -89071,11 +89071,11 @@ const io_1 = __nccwpck_require__(7436);
 const assert_1 = __importDefault(__nccwpck_require__(9491));
 const fs_1 = __importDefault(__nccwpck_require__(7147));
 const path_1 = __importDefault(__nccwpck_require__(1017));
+const FingerprintDbManager_1 = __nccwpck_require__(7070);
 const cacher_1 = __nccwpck_require__(331);
 const packager_1 = __nccwpck_require__(6466);
 const sqlite_1 = __nccwpck_require__(280);
 const worker_1 = __nccwpck_require__(8912);
-const FingerprintDbManager_1 = __nccwpck_require__(7070);
 __exportStar(__nccwpck_require__(7070), exports);
 /**
  * Shared logic to create a fingerprint diff for fingerprint actions

--- a/build/fingerprint/index.js
+++ b/build/fingerprint/index.js
@@ -89071,11 +89071,11 @@ const io_1 = __nccwpck_require__(7436);
 const assert_1 = __importDefault(__nccwpck_require__(9491));
 const fs_1 = __importDefault(__nccwpck_require__(7147));
 const path_1 = __importDefault(__nccwpck_require__(1017));
-const FingerprintDbManager_1 = __nccwpck_require__(7070);
 const cacher_1 = __nccwpck_require__(331);
 const packager_1 = __nccwpck_require__(6466);
 const sqlite_1 = __nccwpck_require__(280);
 const worker_1 = __nccwpck_require__(8912);
+const FingerprintDbManager_1 = __nccwpck_require__(7070);
 __exportStar(__nccwpck_require__(7070), exports);
 /**
  * Shared logic to create a fingerprint diff for fingerprint actions
@@ -89127,10 +89127,12 @@ function collectFingerprintActionInput() {
         fingerprintVersion: (0, core_1.getInput)('fingerprint-version') || 'latest',
         fingerprintInstallationCache: !(0, core_1.getInput)('fingerprint-installation-cache') || (0, core_1.getBooleanInput)('fingerprint-installation-cache'),
         fingerprintDbCacheKey: (0, core_1.getInput)('fingerprint-db-cache-key'),
-        previousGitCommitHash: github_1.context.eventName === 'pull_request'
-            ? github_1.context.payload.pull_request?.base?.sha
-            : github_1.context.payload.before,
-        currentGitCommitHash: github_1.context.eventName === 'pull_request' ? github_1.context.payload.pull_request?.head?.sha : github_1.context.sha,
+        previousGitCommitHash: (0, core_1.getInput)('previous-git-commit') ||
+            (github_1.context.eventName === 'pull_request'
+                ? github_1.context.payload.pull_request?.base?.sha
+                : github_1.context.payload.before),
+        currentGitCommitHash: (0, core_1.getInput)('current-git-commit') ||
+            (github_1.context.eventName === 'pull_request' ? github_1.context.payload.pull_request?.head?.sha : github_1.context.sha),
     };
 }
 exports.collectFingerprintActionInput = collectFingerprintActionInput;

--- a/build/preview-build/index.js
+++ b/build/preview-build/index.js
@@ -89649,11 +89649,11 @@ const io_1 = __nccwpck_require__(7436);
 const assert_1 = __importDefault(__nccwpck_require__(9491));
 const fs_1 = __importDefault(__nccwpck_require__(7147));
 const path_1 = __importDefault(__nccwpck_require__(1017));
+const FingerprintDbManager_1 = __nccwpck_require__(7070);
 const cacher_1 = __nccwpck_require__(331);
 const packager_1 = __nccwpck_require__(6466);
 const sqlite_1 = __nccwpck_require__(280);
 const worker_1 = __nccwpck_require__(8912);
-const FingerprintDbManager_1 = __nccwpck_require__(7070);
 __exportStar(__nccwpck_require__(7070), exports);
 /**
  * Shared logic to create a fingerprint diff for fingerprint actions

--- a/build/preview-build/index.js
+++ b/build/preview-build/index.js
@@ -89649,11 +89649,11 @@ const io_1 = __nccwpck_require__(7436);
 const assert_1 = __importDefault(__nccwpck_require__(9491));
 const fs_1 = __importDefault(__nccwpck_require__(7147));
 const path_1 = __importDefault(__nccwpck_require__(1017));
-const FingerprintDbManager_1 = __nccwpck_require__(7070);
 const cacher_1 = __nccwpck_require__(331);
 const packager_1 = __nccwpck_require__(6466);
 const sqlite_1 = __nccwpck_require__(280);
 const worker_1 = __nccwpck_require__(8912);
+const FingerprintDbManager_1 = __nccwpck_require__(7070);
 __exportStar(__nccwpck_require__(7070), exports);
 /**
  * Shared logic to create a fingerprint diff for fingerprint actions
@@ -89705,10 +89705,12 @@ function collectFingerprintActionInput() {
         fingerprintVersion: (0, core_1.getInput)('fingerprint-version') || 'latest',
         fingerprintInstallationCache: !(0, core_1.getInput)('fingerprint-installation-cache') || (0, core_1.getBooleanInput)('fingerprint-installation-cache'),
         fingerprintDbCacheKey: (0, core_1.getInput)('fingerprint-db-cache-key'),
-        previousGitCommitHash: github_1.context.eventName === 'pull_request'
-            ? github_1.context.payload.pull_request?.base?.sha
-            : github_1.context.payload.before,
-        currentGitCommitHash: github_1.context.eventName === 'pull_request' ? github_1.context.payload.pull_request?.head?.sha : github_1.context.sha,
+        previousGitCommitHash: (0, core_1.getInput)('previous-git-commit') ||
+            (github_1.context.eventName === 'pull_request'
+                ? github_1.context.payload.pull_request?.base?.sha
+                : github_1.context.payload.before),
+        currentGitCommitHash: (0, core_1.getInput)('current-git-commit') ||
+            (github_1.context.eventName === 'pull_request' ? github_1.context.payload.pull_request?.head?.sha : github_1.context.sha),
     };
 }
 exports.collectFingerprintActionInput = collectFingerprintActionInput;

--- a/fingerprint/action.yml
+++ b/fingerprint/action.yml
@@ -33,6 +33,12 @@ inputs:
     description: A cache key to use for saving the fingerprint database
     required: false
     default: fingerprint-db
+  previous-git-commit:
+    description: The Git hash for the base commit
+    required: false
+  current-git-commit:
+    description: The Git hash for the current commit
+    required: false
 
 outputs:
   previous-fingerprint:

--- a/src/fingerprint/index.ts
+++ b/src/fingerprint/index.ts
@@ -6,11 +6,11 @@ import assert from 'assert';
 import fs from 'fs';
 import path from 'path';
 
-import { FingerprintDbEntity, FingerprintDbManager } from './FingerprintDbManager';
 import { restoreCacheAsync, restoreFromCache, saveCacheAsync, saveToCache } from '../cacher';
 import { installPackage, resolvePackage } from '../packager';
 import { installSQLiteAsync } from '../sqlite';
 import { addGlobalNodeSearchPath, findTool, installToolFromPackage } from '../worker';
+import { FingerprintDbEntity, FingerprintDbManager } from './FingerprintDbManager';
 
 export * from './FingerprintDbManager';
 
@@ -81,11 +81,13 @@ export function collectFingerprintActionInput() {
       !getInput('fingerprint-installation-cache') || getBooleanInput('fingerprint-installation-cache'),
     fingerprintDbCacheKey: getInput('fingerprint-db-cache-key'),
     previousGitCommitHash:
-      githubContext.eventName === 'pull_request'
+      getInput('previous-git-commit') ||
+      (githubContext.eventName === 'pull_request'
         ? githubContext.payload.pull_request?.base?.sha
-        : githubContext.payload.before,
+        : githubContext.payload.before),
     currentGitCommitHash:
-      githubContext.eventName === 'pull_request' ? githubContext.payload.pull_request?.head?.sha : githubContext.sha,
+      getInput('current-git-commit') ||
+      (githubContext.eventName === 'pull_request' ? githubContext.payload.pull_request?.head?.sha : githubContext.sha),
   };
 }
 

--- a/src/fingerprint/index.ts
+++ b/src/fingerprint/index.ts
@@ -6,11 +6,11 @@ import assert from 'assert';
 import fs from 'fs';
 import path from 'path';
 
+import { FingerprintDbEntity, FingerprintDbManager } from './FingerprintDbManager';
 import { restoreCacheAsync, restoreFromCache, saveCacheAsync, saveToCache } from '../cacher';
 import { installPackage, resolvePackage } from '../packager';
 import { installSQLiteAsync } from '../sqlite';
 import { addGlobalNodeSearchPath, findTool, installToolFromPackage } from '../worker';
-import { FingerprintDbEntity, FingerprintDbManager } from './FingerprintDbManager';
 
 export * from './FingerprintDbManager';
 


### PR DESCRIPTION
# Why

on expo/expo repos, we need the custom base commit because we don't run fingerprint for every commit. this pr added the advanced and customized `previous-git-commit` input