### PR TITLE
[fingerprint] add saving-db-branch

### DIFF
--- a/build/command/index.js
+++ b/build/command/index.js
@@ -38953,7 +38953,7 @@ exports.getBuildLogsUrl = getBuildLogsUrl;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getPullRequestFromGitCommitShaAsync = exports.isPushDefaultBranchContext = exports.getGitCommandMessageAsync = exports.issueComment = exports.createReaction = exports.hasPullContext = exports.pullContext = exports.githubApi = exports.createIssueComment = exports.fetchIssueComment = void 0;
+exports.getPullRequestFromGitCommitShaAsync = exports.isPushBranchContext = exports.getRepoDefaultBranch = exports.getGitCommandMessageAsync = exports.issueComment = exports.createReaction = exports.hasPullContext = exports.pullContext = exports.githubApi = exports.createIssueComment = exports.fetchIssueComment = void 0;
 const github_1 = __nccwpck_require__(5438);
 const assert_1 = __nccwpck_require__(9491);
 /**
@@ -39077,12 +39077,21 @@ async function getGitCommandMessageAsync(options, gitCommitHash) {
 }
 exports.getGitCommandMessageAsync = getGitCommandMessageAsync;
 /**
- * True if the current event is a push to the default branch.
+ * Get the default branch for the repository.
  */
-function isPushDefaultBranchContext() {
-    return github_1.context.eventName === 'push' && github_1.context.ref === `refs/heads/${github_1.context.payload?.repository?.default_branch}`;
+function getRepoDefaultBranch() {
+    return github_1.context.payload?.repository?.default_branch;
 }
-exports.isPushDefaultBranchContext = isPushDefaultBranchContext;
+exports.getRepoDefaultBranch = getRepoDefaultBranch;
+/**
+ * True if the current event is a push to the target branch.
+ *
+ * @param targetBranch The branch to compare against.
+ */
+function isPushBranchContext(targetBranch) {
+    return github_1.context.eventName === 'push' && github_1.context.ref === `refs/heads/${targetBranch}`;
+}
+exports.isPushBranchContext = isPushBranchContext;
 /**
  * Get the pull request information that associated with a specific commit hash.
  */

--- a/build/fingerprint/index.js
+++ b/build/fingerprint/index.js
@@ -89133,6 +89133,7 @@ function collectFingerprintActionInput() {
                 : github_1.context.payload.before),
         currentGitCommitHash: (0, core_1.getInput)('current-git-commit') ||
             (github_1.context.eventName === 'pull_request' ? github_1.context.payload.pull_request?.head?.sha : github_1.context.sha),
+        savingDbBranch: (0, core_1.getInput)('saving-db-branch') || undefined,
     };
 }
 exports.collectFingerprintActionInput = collectFingerprintActionInput;
@@ -89201,7 +89202,7 @@ async function getDbPathAsync() {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getPullRequestFromGitCommitShaAsync = exports.isPushDefaultBranchContext = exports.getGitCommandMessageAsync = exports.issueComment = exports.createReaction = exports.hasPullContext = exports.pullContext = exports.githubApi = exports.createIssueComment = exports.fetchIssueComment = void 0;
+exports.getPullRequestFromGitCommitShaAsync = exports.isPushBranchContext = exports.getRepoDefaultBranch = exports.getGitCommandMessageAsync = exports.issueComment = exports.createReaction = exports.hasPullContext = exports.pullContext = exports.githubApi = exports.createIssueComment = exports.fetchIssueComment = void 0;
 const github_1 = __nccwpck_require__(5438);
 const assert_1 = __nccwpck_require__(9491);
 /**
@@ -89325,12 +89326,21 @@ async function getGitCommandMessageAsync(options, gitCommitHash) {
 }
 exports.getGitCommandMessageAsync = getGitCommandMessageAsync;
 /**
- * True if the current event is a push to the default branch.
+ * Get the default branch for the repository.
  */
-function isPushDefaultBranchContext() {
-    return github_1.context.eventName === 'push' && github_1.context.ref === `refs/heads/${github_1.context.payload?.repository?.default_branch}`;
+function getRepoDefaultBranch() {
+    return github_1.context.payload?.repository?.default_branch;
 }
-exports.isPushDefaultBranchContext = isPushDefaultBranchContext;
+exports.getRepoDefaultBranch = getRepoDefaultBranch;
+/**
+ * True if the current event is a push to the target branch.
+ *
+ * @param targetBranch The branch to compare against.
+ */
+function isPushBranchContext(targetBranch) {
+    return github_1.context.eventName === 'push' && github_1.context.ref === `refs/heads/${targetBranch}`;
+}
+exports.isPushBranchContext = isPushBranchContext;
 /**
  * Get the pull request information that associated with a specific commit hash.
  */

--- a/build/preview-comment/index.js
+++ b/build/preview-comment/index.js
@@ -38897,7 +38897,7 @@ exports.getBuildLogsUrl = getBuildLogsUrl;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getPullRequestFromGitCommitShaAsync = exports.isPushDefaultBranchContext = exports.getGitCommandMessageAsync = exports.issueComment = exports.createReaction = exports.hasPullContext = exports.pullContext = exports.githubApi = exports.createIssueComment = exports.fetchIssueComment = void 0;
+exports.getPullRequestFromGitCommitShaAsync = exports.isPushBranchContext = exports.getRepoDefaultBranch = exports.getGitCommandMessageAsync = exports.issueComment = exports.createReaction = exports.hasPullContext = exports.pullContext = exports.githubApi = exports.createIssueComment = exports.fetchIssueComment = void 0;
 const github_1 = __nccwpck_require__(5438);
 const assert_1 = __nccwpck_require__(9491);
 /**
@@ -39021,12 +39021,21 @@ async function getGitCommandMessageAsync(options, gitCommitHash) {
 }
 exports.getGitCommandMessageAsync = getGitCommandMessageAsync;
 /**
- * True if the current event is a push to the default branch.
+ * Get the default branch for the repository.
  */
-function isPushDefaultBranchContext() {
-    return github_1.context.eventName === 'push' && github_1.context.ref === `refs/heads/${github_1.context.payload?.repository?.default_branch}`;
+function getRepoDefaultBranch() {
+    return github_1.context.payload?.repository?.default_branch;
 }
-exports.isPushDefaultBranchContext = isPushDefaultBranchContext;
+exports.getRepoDefaultBranch = getRepoDefaultBranch;
+/**
+ * True if the current event is a push to the target branch.
+ *
+ * @param targetBranch The branch to compare against.
+ */
+function isPushBranchContext(targetBranch) {
+    return github_1.context.eventName === 'push' && github_1.context.ref === `refs/heads/${targetBranch}`;
+}
+exports.isPushBranchContext = isPushBranchContext;
 /**
  * Get the pull request information that associated with a specific commit hash.
  */

--- a/build/preview/index.js
+++ b/build/preview/index.js
@@ -42413,7 +42413,7 @@ exports.getBuildLogsUrl = getBuildLogsUrl;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getPullRequestFromGitCommitShaAsync = exports.isPushDefaultBranchContext = exports.getGitCommandMessageAsync = exports.issueComment = exports.createReaction = exports.hasPullContext = exports.pullContext = exports.githubApi = exports.createIssueComment = exports.fetchIssueComment = void 0;
+exports.getPullRequestFromGitCommitShaAsync = exports.isPushBranchContext = exports.getRepoDefaultBranch = exports.getGitCommandMessageAsync = exports.issueComment = exports.createReaction = exports.hasPullContext = exports.pullContext = exports.githubApi = exports.createIssueComment = exports.fetchIssueComment = void 0;
 const github_1 = __nccwpck_require__(5438);
 const assert_1 = __nccwpck_require__(9491);
 /**
@@ -42537,12 +42537,21 @@ async function getGitCommandMessageAsync(options, gitCommitHash) {
 }
 exports.getGitCommandMessageAsync = getGitCommandMessageAsync;
 /**
- * True if the current event is a push to the default branch.
+ * Get the default branch for the repository.
  */
-function isPushDefaultBranchContext() {
-    return github_1.context.eventName === 'push' && github_1.context.ref === `refs/heads/${github_1.context.payload?.repository?.default_branch}`;
+function getRepoDefaultBranch() {
+    return github_1.context.payload?.repository?.default_branch;
 }
-exports.isPushDefaultBranchContext = isPushDefaultBranchContext;
+exports.getRepoDefaultBranch = getRepoDefaultBranch;
+/**
+ * True if the current event is a push to the target branch.
+ *
+ * @param targetBranch The branch to compare against.
+ */
+function isPushBranchContext(targetBranch) {
+    return github_1.context.eventName === 'push' && github_1.context.ref === `refs/heads/${targetBranch}`;
+}
+exports.isPushBranchContext = isPushBranchContext;
 /**
  * Get the pull request information that associated with a specific commit hash.
  */

--- a/build/setup/index.js
+++ b/build/setup/index.js
@@ -89174,7 +89174,7 @@ exports.getBuildLogsUrl = getBuildLogsUrl;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getPullRequestFromGitCommitShaAsync = exports.isPushDefaultBranchContext = exports.getGitCommandMessageAsync = exports.issueComment = exports.createReaction = exports.hasPullContext = exports.pullContext = exports.githubApi = exports.createIssueComment = exports.fetchIssueComment = void 0;
+exports.getPullRequestFromGitCommitShaAsync = exports.isPushBranchContext = exports.getRepoDefaultBranch = exports.getGitCommandMessageAsync = exports.issueComment = exports.createReaction = exports.hasPullContext = exports.pullContext = exports.githubApi = exports.createIssueComment = exports.fetchIssueComment = void 0;
 const github_1 = __nccwpck_require__(5438);
 const assert_1 = __nccwpck_require__(9491);
 /**
@@ -89298,12 +89298,21 @@ async function getGitCommandMessageAsync(options, gitCommitHash) {
 }
 exports.getGitCommandMessageAsync = getGitCommandMessageAsync;
 /**
- * True if the current event is a push to the default branch.
+ * Get the default branch for the repository.
  */
-function isPushDefaultBranchContext() {
-    return github_1.context.eventName === 'push' && github_1.context.ref === `refs/heads/${github_1.context.payload?.repository?.default_branch}`;
+function getRepoDefaultBranch() {
+    return github_1.context.payload?.repository?.default_branch;
 }
-exports.isPushDefaultBranchContext = isPushDefaultBranchContext;
+exports.getRepoDefaultBranch = getRepoDefaultBranch;
+/**
+ * True if the current event is a push to the target branch.
+ *
+ * @param targetBranch The branch to compare against.
+ */
+function isPushBranchContext(targetBranch) {
+    return github_1.context.eventName === 'push' && github_1.context.ref === `refs/heads/${targetBranch}`;
+}
+exports.isPushBranchContext = isPushBranchContext;
 /**
  * Get the pull request information that associated with a specific commit hash.
  */

--- a/fingerprint/action.yml
+++ b/fingerprint/action.yml
@@ -39,6 +39,9 @@ inputs:
   current-git-commit:
     description: The Git hash for the current commit
     required: false
+  saving-db-branch:
+    description: The branch for saving the fingerprint database. Defaults to the repository's default branch
+    required: false
 
 outputs:
   previous-fingerprint:

--- a/preview-build/action.yml
+++ b/preview-build/action.yml
@@ -42,6 +42,15 @@ inputs:
     default: fingerprint-db
   eas-build-message:
     description: A short message describing the build
+  previous-git-commit:
+    description: The Git hash for the base commit
+    required: false
+  current-git-commit:
+    description: The Git hash for the current commit
+    required: false
+  saving-db-branch:
+    description: The branch for saving the fingerprint database. Defaults to the repository's default branch
+    required: false
 
 outputs:
   projectId:

--- a/src/actions/fingerprint-post.ts
+++ b/src/actions/fingerprint-post.ts
@@ -3,15 +3,18 @@ import assert from 'assert';
 
 import { deleteCacheAsync } from '../cacher';
 import { collectFingerprintActionInput, saveDbToCacheAsync } from '../fingerprint';
-import { isPushDefaultBranchContext } from '../github';
+import { getRepoDefaultBranch, isPushBranchContext } from '../github';
 import { executeAction } from '../worker';
 
 executeAction(runAction);
 
 export async function runAction(input = collectFingerprintActionInput()) {
-  if (!isPushDefaultBranchContext()) {
+  const targetBranch = input.savingDbBranch ?? getRepoDefaultBranch();
+  assert(targetBranch);
+  if (!isPushBranchContext(targetBranch)) {
     return;
   }
+  info(`Saving fingerprint database to ${targetBranch} branch.`);
 
   try {
     const ref = process.env.GITHUB_REF;

--- a/src/fingerprint/index.ts
+++ b/src/fingerprint/index.ts
@@ -88,6 +88,7 @@ export function collectFingerprintActionInput() {
     currentGitCommitHash:
       getInput('current-git-commit') ||
       (githubContext.eventName === 'pull_request' ? githubContext.payload.pull_request?.head?.sha : githubContext.sha),
+    savingDbBranch: getInput('saving-db-branch') || undefined,
   };
 }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -155,10 +155,19 @@ export async function getGitCommandMessageAsync(options: AuthContext, gitCommitH
 }
 
 /**
- * True if the current event is a push to the default branch.
+ * Get the default branch for the repository.
  */
-export function isPushDefaultBranchContext() {
-  return context.eventName === 'push' && context.ref === `refs/heads/${context.payload?.repository?.default_branch}`;
+export function getRepoDefaultBranch(): string | undefined {
+  return context.payload?.repository?.default_branch;
+}
+
+/**
+ * True if the current event is a push to the target branch.
+ *
+ * @param targetBranch The branch to compare against.
+ */
+export function isPushBranchContext(targetBranch: string) {
+  return context.eventName === 'push' && context.ref === `refs/heads/${targetBranch}`;
 }
 
 /**


### PR DESCRIPTION
# Why

people have feature request to use non default branch for fingerprinting. currently we only save database when pushing back to the repo's default branch (main branch in most case).

# How

introduce the `saving-db-branch` option to override the default branch name.