### PR TITLE
Add continuous-deploy-fingerprint action

### DIFF
--- a/build/continuous-deploy-fingerprint/license.txt
+++ b/build/continuous-deploy-fingerprint/license.txt
@@ -1,0 +1,835 @@
+@actions/core
+MIT
+The MIT License (MIT)
+
+Copyright 2019 GitHub
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+@actions/exec
+MIT
+The MIT License (MIT)
+
+Copyright 2019 GitHub
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+@actions/github
+MIT
+The MIT License (MIT)
+
+Copyright 2019 GitHub
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+@actions/http-client
+MIT
+Actions Http Client for Node.js
+
+Copyright (c) GitHub, Inc.
+
+All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+@actions/io
+MIT
+The MIT License (MIT)
+
+Copyright 2019 GitHub
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+@actions/tool-cache
+MIT
+The MIT License (MIT)
+
+Copyright 2019 GitHub
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+@fastify/busboy
+MIT
+Copyright Brian White. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+
+@octokit/auth-token
+MIT
+The MIT License
+
+Copyright (c) 2019 Octokit contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+@octokit/core
+MIT
+The MIT License
+
+Copyright (c) 2019 Octokit contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+@octokit/endpoint
+MIT
+The MIT License
+
+Copyright (c) 2018 Octokit contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+@octokit/graphql
+MIT
+The MIT License
+
+Copyright (c) 2018 Octokit contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+@octokit/plugin-paginate-rest
+MIT
+MIT License Copyright (c) 2019 Octokit contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+@octokit/plugin-rest-endpoint-methods
+MIT
+MIT License Copyright (c) 2019 Octokit contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice (including the next paragraph) shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+@octokit/request
+MIT
+The MIT License
+
+Copyright (c) 2018 Octokit contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+@octokit/request-error
+MIT
+The MIT License
+
+Copyright (c) 2019 Octokit contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+before-after-hook
+Apache-2.0
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018 Gregor Martynus and other contributors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+deprecation
+ISC
+The ISC License
+
+Copyright (c) Gregor Martynus and contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+encoding
+MIT
+Copyright (c) 2012-2014 Andris Reinman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+iconv-lite
+MIT
+Copyright (c) 2011 Alexander Shtuchkin
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+is-plain-object
+MIT
+The MIT License (MIT)
+
+Copyright (c) 2014-2017, Jon Schlinkert.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+lru-cache
+ISC
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+node-fetch
+MIT
+The MIT License (MIT)
+
+Copyright (c) 2016 David Frank
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+
+once
+ISC
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+safer-buffer
+MIT
+MIT License
+
+Copyright (c) 2018 Nikita Skovoroda <chalkerx@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+semver
+ISC
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+tr46
+MIT
+
+tunnel
+MIT
+The MIT License (MIT)
+
+Copyright (c) 2012 Koichi Kobayashi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+undici
+MIT
+MIT License
+
+Copyright (c) Matteo Collina and Undici contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+universal-user-agent
+ISC
+# [ISC License](https://spdx.org/licenses/ISC)
+
+Copyright (c) 2018, Gregor Martynus (https://github.com/gr2m)
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+uuid
+MIT
+The MIT License (MIT)
+
+Copyright (c) 2010-2020 Robert Kieffer and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+webidl-conversions
+BSD-2-Clause
+# The BSD 2-Clause License
+
+Copyright (c) 2014, Domenic Denicola
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+whatwg-url
+MIT
+The MIT License (MIT)
+
+Copyright (c) 2015–2016 Sebastian Mayr
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+wrappy
+ISC
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+yallist
+ISC
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/build/preview-build/index.js
+++ b/build/preview-build/index.js
@@ -88807,6 +88807,7 @@ const github_1 = __nccwpck_require__(5438);
 const assert_1 = __importDefault(__nccwpck_require__(9491));
 const uuid_1 = __nccwpck_require__(5840);
 const cacher_1 = __nccwpck_require__(331);
+const comment_1 = __nccwpck_require__(7810);
 const expo_1 = __nccwpck_require__(2489);
 const fingerprint_1 = __nccwpck_require__(3111);
 const github_2 = __nccwpck_require__(978);
@@ -88959,9 +88960,6 @@ function getVariables(config, builds) {
     };
 }
 exports.getVariables = getVariables;
-function createDetails({ summary, details, delim = '\n', }) {
-    return `<details><summary>${summary}</summary>${delim.repeat(2)}${details}${delim}</details>`;
-}
 function createMessageBodyInBuilding(builds, fingerprintDiff, input) {
     const tableRows = [];
     for (const build of builds) {
@@ -88976,7 +88974,7 @@ function createMessageBodyInBuilding(builds, fingerprintDiff, input) {
             name = 'Unknown build';
         }
         const buildPageURL = (0, expo_1.getBuildLogsUrl)(build);
-        const details = createDetails({
+        const details = (0, comment_1.createDetails)({
             summary: 'Details',
             details: [
                 `Distribution: \`${build.distribution}\``,
@@ -88999,7 +88997,7 @@ function createMessageBodyInBuilding(builds, fingerprintDiff, input) {
         '| :-- | :-- | :-- |',
         ...tableRows,
         '',
-        createDetails({
+        (0, comment_1.createDetails)({
             summary: 'Fingerprint diff',
             details: ['```json', JSON.stringify(fingerprintDiff, null, 2), '```'].join('\n'),
         }),
@@ -89235,6 +89233,59 @@ function handleCacheError(error) {
     }
 }
 exports.handleCacheError = handleCacheError;
+
+
+/***/ }),
+
+/***/ 7810:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.createDetails = exports.getSchemesInOrderFromConfig = exports.getQrTarget = void 0;
+const core_1 = __nccwpck_require__(2186);
+const expo_1 = __nccwpck_require__(2489);
+function getQrTarget(input) {
+    if (!input.qrTarget) {
+        const appType = (0, expo_1.projectAppType)(input.workingDirectory);
+        (0, core_1.debug)(`Using inferred QR code target: "${appType}"`);
+        return appType;
+    }
+    switch (input.qrTarget) {
+        // Note, `dev-build` is prefered, but `dev-client` is supported to aovid confusion
+        case 'dev-client':
+        case 'dev-build':
+            (0, core_1.debug)(`Using QR code target: "dev-build"`);
+            return 'dev-build';
+        case 'expo-go':
+            (0, core_1.debug)(`Using QR code target: "expo-go"`);
+            return 'expo-go';
+        default:
+            throw new Error(`Invalid QR code target: "${input.qrTarget}", expected "expo-go" or "dev-build"`);
+    }
+}
+exports.getQrTarget = getQrTarget;
+/**
+ * Retrieve the app schemes, in correct priority order, from project config.
+ *   - If the scheme is a string, return `[scheme]`.
+ *   - If the scheme is an array, return the schemes sorted by length, longest first.
+ *   - If the scheme is empty/incorrect, return an empty array.
+ */
+function getSchemesInOrderFromConfig(config) {
+    if (typeof config.scheme === 'string') {
+        return [config.scheme];
+    }
+    if (Array.isArray(config.scheme)) {
+        return config.scheme.sort((a, b) => b.length - a.length);
+    }
+    return [];
+}
+exports.getSchemesInOrderFromConfig = getSchemesInOrderFromConfig;
+function createDetails({ summary, details, delim = '\n', }) {
+    return `<details><summary>${summary}</summary>${delim.repeat(2)}${details}${delim}</details>`;
+}
+exports.createDetails = createDetails;
 
 
 /***/ }),

--- a/continuous-deploy-fingerprint/README.md
+++ b/continuous-deploy-fingerprint/README.md
@@ -1,0 +1,160 @@
+<div align="center">
+  <h1>continuous-deploy-fingerprint</h1>
+  <p>Continuously deploys an Expo project using EAS Build and EAS Update in combination with fingerprint runtime versions</p>
+</div>
+
+<p align="center">
+  <a href="https://github.com/expo/expo-github-action/releases" title="Latest release">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/github/package-json/v/expo/expo-github-action?style=flat-square&color=0366D6&labelColor=49505A">
+      <img alt="Latest release" src="https://img.shields.io/github/package-json/v/expo/expo-github-action?style=flat-square&color=0366D6&labelColor=D1D5DA" />
+    </picture>
+  </a>
+  <a href="https://github.com/expo/expo-github-action/actions" title="Workflow status">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/github/actions/workflow/status/expo/expo-github-action/test.yml?branch=main&style=flat-square&labelColor=49505A">
+      <img alt="Workflow status" src="https://img.shields.io/github/actions/workflow/status/expo/expo-github-action/test.yml?branch=main&style=flat-square&labelColor=D1D5DA" />
+    </picture>
+  </a>
+</p>
+
+<p align="center">
+  <a href="#usage"><b>Usage</b></a>
+  &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+  <a href="#available-outputs"><b>Outputs</b></a>
+  &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+  <a href="#example-workflows"><b>Examples</b></a>
+  &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+  <a href="#caveats"><b>Caveats</b></a>
+  &nbsp;&nbsp;&mdash;&nbsp;&nbsp;
+  <a href="https://github.com/expo/expo-github-action/blob/main/CHANGELOG.md"><b>Changelog</b></a>
+</p>
+
+<br />
+
+> **Warning**
+> This sub action is experimental and might change without notice. Use it at your own risk.
+
+## Overview
+
+`continuous-deploy-fingerprint` is a GitHub Action continuously deploys an Expo project using the expo-updates fingerprint runtime version policy. When run, it performs the following tasks in order, once for each platform:
+1. Check current fingerprint of the project.
+2. Check for EAS builds with specified profile matching that fingerprint.
+3. If an EAS build doesn't exist, start one.
+4. Publish an update on EAS update.
+5. If run on a PR, post a comment indicating what was done.
+
+### Configuration options
+
+This action is customizable through variables defined in the [`action.yml`](action.yml).
+Here is a summary of all the input options you can use.
+
+| variable                           | default          | description                                                             |
+| ---------------------------------- | ---------------- | ----------------------------------------------------------------------- |
+| **profile**                        | (required)       | The EAS Build profile to use |
+| **branch**                     | (required)       | The EAS Update branch on which to publish |
+| **working-directory**              | -                | The relative directory of your Expo app                                 |
+| **github-token**                   | `github.token`   | GitHub token to use when commenting on PR ([read more](#github-tokens)) |
+
+And the action will generate these [outputs](#available-outputs) for other actions to do something based on what this action did.
+
+### Available outputs
+
+In case you want to reuse this action for other purpose, this action will set the following action outputs.
+
+| output name              | description                                                                                                                                                                                   |
+| ------------------------ | ------------------------------ |
+| **ios-fingerprint**      | The iOS fingerprint of the current commit.          |
+| **android-fingerprint**  | The Android fingerprint of the current commit.                 |
+| **android-build-id**  | ID for Android EAS Build if one was started. |
+| **ios-build-id**  | ID for iOS EAS Build if one was started.         |
+| **update-output**     | The output (JSON) from the `eas update` command. |
+
+## Caveats
+
+### GitHub tokens
+
+When using the GitHub API, you always need to be authenticated.
+This action tries to auto-authenticate using the [Automatic token authentication][link-gha-token] from GitHub.
+You can overwrite the token by adding the `GITHUB_TOKEN` environment variable or add the **github-token** input.
+
+<div align="center">
+  <br />
+  with :heart:&nbsp;<strong>Expo</strong>
+  <br />
+</div>
+
+## Example workflows
+
+Before diving into the workflow examples, you should know the basics of GitHub Actions.
+You can read more about this in the [GitHub Actions documentation][link-actions].
+
+### Continuously deploy after tests on main branch and pull requests
+
+This workflow continuously deploys:
+- main branch -> production EAS Build profile and EAS Update branch
+- PR branches -> development EAS Build profile and EAS Update branch
+
+This means that every commit landed to main will go out to users on production. If a new build is created, it will need to be manually submitted to the app stores.
+
+Pull requests also do a build if necessary and display a QR code to scan to preview the latest commit on the PR.
+
+```yml
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize]
+
+env:
+  EXPO_STAGING: 1
+  EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v4
+      - name: 🏗 Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+          cache: yarn
+      - name: 📦 Install dependencies
+        run: yarn install
+      - name: 🧪 Run tests
+        run: yarn test
+
+  continuously-deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    concurrency: continuous-deploy-fingerprint-${{ github.event_name != 'pull_request' && 'main' || github.run_id }}
+    permissions:
+      contents: read # Allow checkout
+      pull-requests: write # Allow comments on PRs
+    steps:
+      - name: 🏗 Setup repo
+        uses: actions/checkout@v4
+
+      - name: 🏗 Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+
+      - name: 📦 Install dependencies
+        run: yarn install
+
+      - name: 🏗 Setup EAS
+        uses: expo/expo-github-action@main
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Continuously Deploy
+        uses: expo/expo-github-action/continuous-deploy-fingerprint@main
+        with:
+          profile: ${{ github.event_name != 'pull_request' && 'production' || 'development' }}
+          branch: ${{ github.event_name != 'pull_request' && 'production' || 'development' }}
+```

--- a/continuous-deploy-fingerprint/action.yml
+++ b/continuous-deploy-fingerprint/action.yml
@@ -1,0 +1,37 @@
+---
+name: Expo GitHub Action - Continuous Deploy Fingerprint
+author: Expo
+description: Continuously deploy an Expo project using EAS Build and EAS Update with fingerprint.
+branding:
+  icon: smartphone
+  color: gray-dark
+runs:
+  using: node20
+  main: ../build/continuous-deploy-fingerprint/index.js
+inputs:
+  profile:
+    description: The EAS Build profile to use, must have EAS Update channel specified in eas.json
+    required: true
+  branch:
+    description: The EAS Update branch on which to publish.
+    required: true
+  github-token:
+    description: GitHub token to use when commenting on PR
+    required: false
+    default: ${{ github.token }}
+  working-directory:
+    description: The relative directory of your Expo app
+    required: false
+    default: ${{ github.workspace }}
+
+outputs:
+  android-fingerprint:
+    description: The Android fingerprint of the current commit.
+  ios-fingerprint:
+    description: The iOS fingerprint of the current commit.
+  android-build-id:
+    description: ID for Android EAS Build if one was started
+  ios-build-id:
+    description: ID for iOS EAS Build if one was started.
+  update-output:
+    description: The output (JSON) from the `eas update` command

--- a/src/actions/continuous-deploy-fingerprint.ts
+++ b/src/actions/continuous-deploy-fingerprint.ts
@@ -1,0 +1,318 @@
+import { getInput, info, setFailed, setOutput } from '@actions/core';
+import { getExecOutput } from '@actions/exec';
+import { which } from '@actions/io';
+import { ExpoConfig } from '@expo/config';
+
+import { createDetails, getQrTarget, getSchemesInOrderFromConfig } from '../comment';
+import { EasUpdate, getUpdateGroupQr, getUpdateGroupWebsite } from '../eas';
+import { AppPlatform, BuildInfo, appPlatformEmojis, getBuildLogsUrl } from '../expo';
+import { createIssueComment, hasPullContext, pullContext } from '../github';
+import { loadProjectConfig } from '../project';
+import { executeAction } from '../worker';
+
+export function collectContinuousDeployFingerprintInput() {
+  return {
+    profile: getInput('profile'),
+    branch: getInput('branch'),
+    githubToken: getInput('github-token'),
+    workingDirectory: getInput('working-directory'),
+  };
+}
+
+executeAction(continuousDeployFingerprintAction);
+
+export async function continuousDeployFingerprintAction(input = collectContinuousDeployFingerprintInput()) {
+  const config = await loadProjectConfig(input.workingDirectory);
+  const projectId = config.extra?.eas?.projectId;
+  if (!projectId) {
+    return setFailed(`Missing 'extra.eas.projectId' in app.json or app.config.js.`);
+  }
+
+  const androidFingerprintHash = await getFingerprintHashForPlatformAsync({
+    cwd: input.workingDirectory,
+    platform: 'android',
+  });
+  const iosFingerprintHash = await getFingerprintHashForPlatformAsync({ cwd: input.workingDirectory, platform: 'ios' });
+
+  info(`Android fingerprint: ${androidFingerprintHash}`);
+  info(`iOS fingerprint: ${iosFingerprintHash}`);
+
+  let androidBuildInfo = await getBuildInfoWithFingerprintAsync({
+    cwd: input.workingDirectory,
+    platform: 'android',
+    profile: input.profile,
+    fingerprintHash: androidFingerprintHash,
+  });
+  if (androidBuildInfo) {
+    info(`Existing Android build found for fingerprint: ${androidBuildInfo.id}`);
+  } else {
+    info(`No existing Android build found for fingerprint, starting a new build...`);
+    androidBuildInfo = await createEASBuildAsync({
+      cwd: input.workingDirectory,
+      platform: 'android',
+      profile: input.profile,
+    });
+  }
+
+  let iosBuildInfo = await getBuildInfoWithFingerprintAsync({
+    cwd: input.workingDirectory,
+    platform: 'ios',
+    profile: input.profile,
+    fingerprintHash: iosFingerprintHash,
+  });
+  if (iosBuildInfo) {
+    info(`Existing iOS build found for fingerprint: ${iosBuildInfo.id}`);
+  } else {
+    info(`No existing iOS build found for fingerprint, starting a new build...`);
+    iosBuildInfo = await createEASBuildAsync({ cwd: input.workingDirectory, platform: 'ios', profile: input.profile });
+  }
+
+  const builds = [androidBuildInfo, iosBuildInfo];
+
+  info(`Publishing EAS Update`);
+
+  const updates = await publishEASUpdatesAsync({
+    cwd: input.workingDirectory,
+    branch: input.branch,
+  });
+
+  if (!hasPullContext()) {
+    info(`Skipped comment: action was not run from a pull request`);
+  } else {
+    const messageId = `continuous-deploy-fingerprint-projectId:${projectId}`;
+    const messageBody = createSummaryForUpdatesAndBuilds({ config, projectId, updates, builds, options: input });
+
+    await createIssueComment({
+      ...pullContext(),
+      token: input.githubToken,
+      id: messageId,
+      body: messageBody,
+    });
+  }
+
+  setOutput('android-fingerprint', androidFingerprintHash);
+  setOutput('ios-fingerprint', iosFingerprintHash);
+  setOutput('android-build-id', androidBuildInfo.id);
+  setOutput('ios-build-id', iosBuildInfo.id);
+  setOutput('update-output', updates);
+}
+
+async function getFingerprintHashForPlatformAsync({
+  cwd,
+  platform,
+}: {
+  cwd: string;
+  platform: 'ios' | 'android';
+}): Promise<string> {
+  try {
+    const { stdout } = await getExecOutput('npx', ['expo-updates', 'fingerprint:generate', '--platform', platform], {
+      cwd,
+    });
+    const { hash } = JSON.parse(stdout);
+    if (!hash || typeof hash !== 'string') {
+      throw new Error(`Invalid fingerprint output: ${stdout}`);
+    }
+    return hash;
+  } catch (error: unknown) {
+    throw new Error(`Could not get fingerprint for project: ${String(error)}`);
+  }
+}
+
+async function getBuildInfoWithFingerprintAsync({
+  cwd,
+  platform,
+  profile,
+  fingerprintHash,
+}: {
+  cwd: string;
+  platform: 'ios' | 'android';
+  profile: string;
+  fingerprintHash: string;
+}): Promise<BuildInfo | null> {
+  let stdout;
+  try {
+    const execOutput = await getExecOutput(
+      await which('eas', true),
+      [
+        'build:list',
+        '--platform',
+        platform,
+        '--status',
+        'finished',
+        '--buildProfile',
+        profile,
+        '--runtimeVersion',
+        fingerprintHash,
+        '--limit',
+        '1',
+        '--json',
+        '--non-interactive',
+      ],
+      {
+        cwd,
+      }
+    );
+    stdout = execOutput.stdout;
+  } catch (error: unknown) {
+    throw new Error(`Could not list project builds: ${String(error)}`);
+  }
+
+  const builds = JSON.parse(stdout);
+  if (!builds || !Array.isArray(builds)) {
+    throw new Error(`Could not get EAS builds for project`);
+  }
+
+  if (!builds[0]) {
+    return null;
+  }
+
+  return builds[0];
+}
+
+async function createEASBuildAsync({
+  cwd,
+  profile,
+  platform,
+}: {
+  cwd: string;
+  profile: string;
+  platform: 'ios' | 'android';
+}): Promise<BuildInfo> {
+  let stdout;
+  try {
+    const execOutput = await getExecOutput(
+      await which('eas', true),
+      [
+        'build',
+        '--profile',
+        profile,
+        '--platform',
+        platform,
+        '--non-interactive',
+        '--json',
+        '--no-wait',
+        '--build-logger-level',
+        'debug',
+      ],
+      {
+        cwd,
+      }
+    );
+    stdout = execOutput.stdout;
+  } catch (error: unknown) {
+    throw new Error(`Could not run command eas build: ${String(error)}`);
+  }
+
+  return JSON.parse(stdout);
+}
+
+async function publishEASUpdatesAsync({ cwd, branch }: { cwd: string; branch: string }): Promise<EasUpdate[]> {
+  let stdout = '';
+
+  try {
+    ({ stdout } = await getExecOutput(
+      await which('eas', true),
+      ['update', '--auto', '--branch', branch, '--non-interactive', '--json'],
+      {
+        cwd,
+      }
+    ));
+  } catch (error: unknown) {
+    throw new Error(`Could not create a new EAS Update: ${String(error)}`);
+  }
+
+  return JSON.parse(stdout);
+}
+
+function createSummaryForUpdatesAndBuilds({
+  config,
+  projectId,
+  updates,
+  builds,
+  options,
+}: {
+  config: ExpoConfig;
+  projectId: string;
+  updates: EasUpdate[];
+  builds: BuildInfo[];
+  options: { qrTarget?: 'expo-go' | 'dev-build' | 'dev-client'; workingDirectory: string };
+}) {
+  const appSlug = config.slug;
+  const qrTarget = getQrTarget(options);
+  const appSchemes = getSchemesInOrderFromConfig(config) || [];
+
+  const androidBuild = builds.find(build => build.platform === AppPlatform.Android);
+  const iosBuild = builds.find(build => build.platform === AppPlatform.Ios);
+
+  const androidUpdate = updates.find(update => update.platform === 'android');
+  const iosUpdate = updates.find(update => update.platform === 'ios');
+
+  const getBuildLink = (build: BuildInfo | undefined) =>
+    build ? `[Build Permalink](${getBuildLogsUrl(build)})` : 'n/a';
+  const getUpdateLink = (update: EasUpdate | undefined) =>
+    update ? `[Update Permalink](${getUpdateGroupWebsite({ projectId, updateGroupId: update.group })})` : 'n/a';
+  const getUpdateQRURL = (update: EasUpdate | undefined) =>
+    update ? getUpdateGroupQr({ projectId, updateGroupId: update.group, appSlug, qrTarget }) : null;
+  const getBuildDetails = (build: BuildInfo | undefined) =>
+    build
+      ? getBuildLink(build) +
+        '<br />' +
+        createDetails({
+          summary: 'Details',
+          details: [
+            `Distribution: \`${build.distribution}\``,
+            `Build profile: \`${build.buildProfile}\``,
+            `Runtime version: \`${build.runtimeVersion}\``,
+            `App version: \`${build.appVersion}\``,
+            `Git commit: \`${build.gitCommitHash}\``,
+          ].join('<br />'),
+          delim: '',
+        })
+      : 'n/a';
+  const getUpdateDetails = (update: EasUpdate | undefined) =>
+    update
+      ? getUpdateLink(update) +
+        '<br />' +
+        createDetails({
+          summary: 'Details',
+          details: [
+            `Branch: \`${update.branch}\``,
+            `Runtime version: \`${update.runtimeVersion}\``,
+            `Git commit: \`${update.gitCommitHash}\``,
+          ].join('<br />'),
+          delim: '',
+        })
+      : 'n/a';
+
+  const androidQRURL = getUpdateQRURL(androidUpdate);
+  const iosQRURL = getUpdateQRURL(iosUpdate);
+
+  const androidQr = androidQRURL
+    ? `<a href="${androidQRURL}"><img src="${androidQRURL}" width="250px" height="250px" /></a>`
+    : null;
+
+  const iosQr = iosQRURL ? `<a href="${iosQRURL}"><img src="${iosQRURL}" width="250px" height="250px" /></a>` : null;
+
+  const platformName = `Platform${updates.length === 1 ? '' : 's'}`;
+  const platformValue = updates
+    .map(update => update.platform)
+    .sort((a, b) => a.localeCompare(b))
+    .map(platform => `**${platform}**`)
+    .join(', ');
+
+  const schemesMessage = appSchemes[0] ? `- Scheme → **${appSchemes.join('**, **')}**` : '';
+
+  return `🚀 Expo continuous deployment is ready!
+
+- Project → **${appSlug}**
+- ${platformName} → ${platformValue}
+${schemesMessage}
+
+&nbsp; | ${appPlatformEmojis[AppPlatform.Android]} Android | ${appPlatformEmojis[AppPlatform.Ios]} iOS
+--- | --- | ---
+Fingerprint | ${androidBuild?.runtimeVersion ?? 'n/a'} | ${iosBuild?.runtimeVersion ?? 'n/a'}
+Build Details | ${getBuildDetails(androidBuild)} | ${getBuildDetails(iosBuild)}
+Update Details | ${getUpdateDetails(androidUpdate)} | ${getUpdateDetails(iosUpdate)}
+Update QR   | ${androidQr ?? 'n/a'} | ${iosQr ?? 'n/a'}
+`;
+}

--- a/src/actions/preview-build.ts
+++ b/src/actions/preview-build.ts
@@ -6,6 +6,7 @@ import assert from 'assert';
 import { validate as isValidUUID } from 'uuid';
 
 import { deleteCacheAsync } from '../cacher';
+import { createDetails } from '../comment';
 import {
   createEasBuildFromRawCommandAsync,
   BuildInfo,
@@ -202,18 +203,6 @@ export function getVariables(config: ExpoConfig, builds: BuildInfo[]) {
     iosLink: ios != null ? getBuildLogsUrl(ios) : '',
     iosAppVersion: ios?.appVersion || '',
   };
-}
-
-function createDetails({
-  summary,
-  details,
-  delim = '\n',
-}: {
-  summary: string;
-  details: string;
-  delim?: string;
-}): string {
-  return `<details><summary>${summary}</summary>${delim.repeat(2)}${details}${delim}</details>`;
 }
 
 function createMessageBodyInBuilding(

--- a/src/actions/preview.ts
+++ b/src/actions/preview.ts
@@ -1,8 +1,8 @@
-import { getBooleanInput, getInput, setOutput, group, setFailed, info, debug } from '@actions/core';
+import { getBooleanInput, getInput, setOutput, group, setFailed, info } from '@actions/core';
 import { ExpoConfig } from '@expo/config';
 
+import { getQrTarget, getSchemesInOrderFromConfig } from '../comment';
 import { assertEasVersion, createUpdate, EasUpdate, getUpdateGroupQr, getUpdateGroupWebsite } from '../eas';
-import { projectAppType } from '../expo';
 import { createIssueComment, hasPullContext, pullContext } from '../github';
 import { loadProjectConfig } from '../project';
 import { template } from '../utils';
@@ -149,47 +149,6 @@ export function getVariables(config: ExpoConfig, updates: EasUpdate[], options: 
     iosQR: ios ? getUpdateGroupQr({ projectId, updateGroupId: ios.group, appSlug, qrTarget }) : '',
     iosLink: ios ? getUpdateGroupWebsite({ projectId, updateGroupId: ios.group }) : '',
   };
-}
-
-export function getQrTarget(input: Pick<ReturnType<typeof previewInput>, 'qrTarget' | 'workingDirectory'>) {
-  if (!input.qrTarget) {
-    const appType = projectAppType(input.workingDirectory);
-    debug(`Using inferred QR code target: "${appType}"`);
-    return appType;
-  }
-
-  switch (input.qrTarget) {
-    // Note, `dev-build` is prefered, but `dev-client` is supported to aovid confusion
-    case 'dev-client':
-    case 'dev-build':
-      debug(`Using QR code target: "dev-build"`);
-      return 'dev-build';
-
-    case 'expo-go':
-      debug(`Using QR code target: "expo-go"`);
-      return 'expo-go';
-
-    default:
-      throw new Error(`Invalid QR code target: "${input.qrTarget}", expected "expo-go" or "dev-build"`);
-  }
-}
-
-/**
- * Retrieve the app schemes, in correct priority order, from project config.
- *   - If the scheme is a string, return `[scheme]`.
- *   - If the scheme is an array, return the schemes sorted by length, longest first.
- *   - If the scheme is empty/incorrect, return an empty array.
- */
-export function getSchemesInOrderFromConfig(config: ExpoConfig) {
-  if (typeof config.scheme === 'string') {
-    return [config.scheme];
-  }
-
-  if (Array.isArray(config.scheme)) {
-    return config.scheme.sort((a, b) => b.length - a.length);
-  }
-
-  return [];
 }
 
 /**

--- a/src/comment.ts
+++ b/src/comment.ts
@@ -1,0 +1,57 @@
+import { debug } from '@actions/core';
+import { ExpoConfig } from '@expo/config';
+
+import { projectAppType } from './expo';
+
+export function getQrTarget(input: { qrTarget?: 'expo-go' | 'dev-build' | 'dev-client'; workingDirectory: string }) {
+  if (!input.qrTarget) {
+    const appType = projectAppType(input.workingDirectory);
+    debug(`Using inferred QR code target: "${appType}"`);
+    return appType;
+  }
+
+  switch (input.qrTarget) {
+    // Note, `dev-build` is prefered, but `dev-client` is supported to aovid confusion
+    case 'dev-client':
+    case 'dev-build':
+      debug(`Using QR code target: "dev-build"`);
+      return 'dev-build';
+
+    case 'expo-go':
+      debug(`Using QR code target: "expo-go"`);
+      return 'expo-go';
+
+    default:
+      throw new Error(`Invalid QR code target: "${input.qrTarget}", expected "expo-go" or "dev-build"`);
+  }
+}
+
+/**
+ * Retrieve the app schemes, in correct priority order, from project config.
+ *   - If the scheme is a string, return `[scheme]`.
+ *   - If the scheme is an array, return the schemes sorted by length, longest first.
+ *   - If the scheme is empty/incorrect, return an empty array.
+ */
+export function getSchemesInOrderFromConfig(config: ExpoConfig) {
+  if (typeof config.scheme === 'string') {
+    return [config.scheme];
+  }
+
+  if (Array.isArray(config.scheme)) {
+    return config.scheme.sort((a, b) => b.length - a.length);
+  }
+
+  return [];
+}
+
+export function createDetails({
+  summary,
+  details,
+  delim = '\n',
+}: {
+  summary: string;
+  details: string;
+  delim?: string;
+}): string {
+  return `<details><summary>${summary}</summary>${delim.repeat(2)}${details}${delim}</details>`;
+}

--- a/src/expo.ts
+++ b/src/expo.ts
@@ -34,9 +34,11 @@ export type BuildInfo = {
       name: string;
     };
   };
-  releaseChannel: string;
+  channel: string;
+  releaseChannel?: string;
   distribution: string;
   buildProfile: string;
+  runtimeVersion?: string;
   sdkVersion: string;
   appVersion: string;
   gitCommitHash: string;

--- a/tests/actions/preview.test.ts
+++ b/tests/actions/preview.test.ts
@@ -1,14 +1,7 @@
 import { ExpoConfig } from '@expo/config';
 
-import {
-  createSummary,
-  getQrTarget,
-  getSchemesInOrderFromConfig,
-  getVariables,
-  previewInput,
-} from '../../src/actions/preview';
+import { createSummary, getVariables, previewInput } from '../../src/actions/preview';
 import { EasUpdate } from '../../src/eas';
-import { projectAppType } from '../../src/expo';
 
 jest.mock('../../src/expo');
 
@@ -49,53 +42,6 @@ const fakeUpdatesSingle: EasUpdate[] = [
 ];
 
 const fakeUpdatesMultiple = fakeUpdatesSingle.map(update => ({ ...update, group: `fake-group-${update.id}` }));
-
-describe(getQrTarget, () => {
-  it('returns `dev-build` for `qr-target: dev-build`', () => {
-    expect(getQrTarget({ ...fakeOptions, qrTarget: 'dev-build' })).toBe('dev-build');
-  });
-
-  it('returns `dev-build` for `qr-target: dev-client`', () => {
-    expect(getQrTarget({ ...fakeOptions, qrTarget: 'dev-client' })).toBe('dev-build');
-  });
-
-  it('returns `expo-go` for `qr-target: expo-go`', () => {
-    expect(getQrTarget({ ...fakeOptions, qrTarget: 'expo-go' })).toBe('expo-go');
-  });
-
-  it('throws for unknown `qr-target`', () => {
-    expect(() => getQrTarget({ ...fakeOptions, qrTarget: 'unknown' } as any)).toThrow(
-      `Invalid QR code target: "unknown", expected "expo-go" or "dev-build"`
-    );
-  });
-
-  it('returns infered `dev-build` when input is omitted', () => {
-    jest.mocked(projectAppType).mockReturnValue('dev-build');
-    expect(getQrTarget({ ...fakeOptions, qrTarget: undefined })).toBe('dev-build');
-  });
-
-  it('returns infered `expo-go` when input is omitted', () => {
-    jest.mocked(projectAppType).mockReturnValue('expo-go');
-    expect(getQrTarget({ ...fakeOptions, qrTarget: undefined })).toBe('expo-go');
-  });
-});
-
-describe(getSchemesInOrderFromConfig, () => {
-  it('returns empty array when not defined', () => {
-    expect(getSchemesInOrderFromConfig({} as ExpoConfig)).toEqual([]);
-  });
-
-  it('returns scheme as array when defined as string', () => {
-    expect(getSchemesInOrderFromConfig({ scheme: 'ega' } as ExpoConfig)).toEqual(['ega']);
-  });
-
-  it('returns schemes in order when defined as array', () => {
-    expect(getSchemesInOrderFromConfig({ scheme: ['ega', 'expogithubaction'] } as ExpoConfig)).toEqual([
-      'expogithubaction',
-      'ega',
-    ]);
-  });
-});
 
 describe(createSummary, () => {
   describe('single update group', () => {

--- a/tests/comment.test.ts
+++ b/tests/comment.test.ts
@@ -1,0 +1,57 @@
+import { ExpoConfig } from '@expo/config';
+
+import { getQrTarget, getSchemesInOrderFromConfig } from '../src/comment';
+import { projectAppType } from '../src/expo';
+
+jest.mock('../src/expo');
+
+const fakeOptions = {
+  workingDirectory: '',
+};
+
+describe(getQrTarget, () => {
+  it('returns `dev-build` for `qr-target: dev-build`', () => {
+    expect(getQrTarget({ ...fakeOptions, qrTarget: 'dev-build' })).toBe('dev-build');
+  });
+
+  it('returns `dev-build` for `qr-target: dev-client`', () => {
+    expect(getQrTarget({ ...fakeOptions, qrTarget: 'dev-client' })).toBe('dev-build');
+  });
+
+  it('returns `expo-go` for `qr-target: expo-go`', () => {
+    expect(getQrTarget({ ...fakeOptions, qrTarget: 'expo-go' })).toBe('expo-go');
+  });
+
+  it('throws for unknown `qr-target`', () => {
+    expect(() => getQrTarget({ ...fakeOptions, qrTarget: 'unknown' } as any)).toThrow(
+      `Invalid QR code target: "unknown", expected "expo-go" or "dev-build"`
+    );
+  });
+
+  it('returns infered `dev-build` when input is omitted', () => {
+    jest.mocked(projectAppType).mockReturnValue('dev-build');
+    expect(getQrTarget({ ...fakeOptions, qrTarget: undefined })).toBe('dev-build');
+  });
+
+  it('returns infered `expo-go` when input is omitted', () => {
+    jest.mocked(projectAppType).mockReturnValue('expo-go');
+    expect(getQrTarget({ ...fakeOptions, qrTarget: undefined })).toBe('expo-go');
+  });
+});
+
+describe(getSchemesInOrderFromConfig, () => {
+  it('returns empty array when not defined', () => {
+    expect(getSchemesInOrderFromConfig({} as ExpoConfig)).toEqual([]);
+  });
+
+  it('returns scheme as array when defined as string', () => {
+    expect(getSchemesInOrderFromConfig({ scheme: 'ega' } as ExpoConfig)).toEqual(['ega']);
+  });
+
+  it('returns schemes in order when defined as array', () => {
+    expect(getSchemesInOrderFromConfig({ scheme: ['ega', 'expogithubaction'] } as ExpoConfig)).toEqual([
+      'expogithubaction',
+      'ega',
+    ]);
+  });
+});


### PR DESCRIPTION
# Why

This adds a new action that automates most of the continuous deploy workflow on PR and main branches for Expo projects using expo-updates and the fingerprint runtime version.

# How

Add actions.

# Test Plan

Test on my own private repos by linking in the action on this branch.

Example workflow: https://github.com/expo/test-fingerprint-updates/blob/main/.github/workflows/continuous-gha.yml
Example workflow run on a PR: https://github.com/expo/test-fingerprint-updates/pull/2
Example workflow run on main after landing: https://github.com/expo/test-fingerprint-updates/actions/runs/8697840027
