### PR TITLE
[continuous-deploy-fingerprint] Exclude expired builds from continuous deploy for development

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,4 @@
 * text=auto
 
 # These files are text and should be normalized (Convert crlf => lf)
-build/** text eol=lf
+build/** text eol=lf linguist-generated=true

--- a/src/expo.ts
+++ b/src/expo.ts
@@ -42,6 +42,7 @@ export type BuildInfo = {
   sdkVersion: string;
   appVersion: string;
   gitCommitHash: string;
+  expirationDate: string;
 };
 
 export const appPlatformDisplayNames: Record<AppPlatform, string> = {


### PR DESCRIPTION
For PRs, we want the printed QR and info to always reference a build that is downloadable. Thus, we need to exclude expired builds.

Test: https://github.com/expo/test-fingerprint-updates-generic/pull/2

Closes ENG-11961.