### PR TITLE
[continuous-deploy-fingerprint] Add platform as input

### DIFF
--- a/continuous-deploy-fingerprint/README.md
+++ b/continuous-deploy-fingerprint/README.md
@@ -55,12 +55,13 @@
 This action is customizable through variables defined in the [`action.yml`](action.yml).
 Here is a summary of all the input options you can use.
 
-| variable                           | default          | description                                                             |
-| ---------------------------------- | ---------------- | ----------------------------------------------------------------------- |
-| **profile**                        | (required)       | The EAS Build profile to use |
-| **branch**                     | (required)       | The EAS Update branch on which to publish |
-| **working-directory**              | -                | The relative directory of your Expo app                                 |
-| **github-token**                   | `github.token`   | GitHub token to use when commenting on PR ([read more](#github-tokens)) |
+| variable              | default        | description                                                                  |
+| --------------------- | -------------- | ---------------------------------------------------------------------------- |
+| **profile**           | (required)     | The EAS Build profile to use                                                 |
+| **branch**            | (required)     | The EAS Update branch on which to publish                                    |
+| **working-directory** | -              | The relative directory of your Expo app                                      |
+| **platform**          | `all`          | The platform to deploy on (available options are `ios`, `android` and `all`) |
+| **github-token**      | `github.token` | GitHub token to use when commenting on PR ([read more](#github-tokens))      |
 
 And the action will generate these [outputs](#available-outputs) for other actions to do something based on what this action did.
 

--- a/continuous-deploy-fingerprint/action.yml
+++ b/continuous-deploy-fingerprint/action.yml
@@ -15,6 +15,10 @@ inputs:
   branch:
     description: The EAS Update branch on which to publish.
     required: true
+  platform:
+    description: The platform on which to publish. Possible values are 'all' | 'android' | 'ios'
+    required: false
+    default: all
   github-token:
     description: GitHub token to use when commenting on PR
     required: false

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/node20",
   "compilerOptions": {
+    "strictNullChecks": true,
     "outDir": "./build",
     "rootDir": "./src",
     "module": "CommonJS",


### PR DESCRIPTION
Playing with the new action for sdk 51, I've noticed that the platform is missing.
This is an attempt to handle this case.