### PR TITLE
[continuous-deploy-fingerprint] Improve build filtering

### DIFF
--- a/build/command/index.js
+++ b/build/command/index.js
@@ -38699,7 +38699,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getBuildLogsUrl = exports.projectDeepLink = exports.projectLink = exports.projectQR = exports.projectAppType = exports.projectInfo = exports.queryEasBuildInfoAsync = exports.cancelEasBuildAsync = exports.createEasBuildFromRawCommandAsync = exports.easBuild = exports.runCommand = exports.projectOwner = exports.authenticate = exports.parseCommand = exports.appPlatformEmojis = exports.appPlatformDisplayNames = exports.AppPlatform = void 0;
+exports.getBuildLogsUrl = exports.projectDeepLink = exports.projectLink = exports.projectQR = exports.projectAppType = exports.projectInfo = exports.queryEasBuildInfoAsync = exports.cancelEasBuildAsync = exports.createEasBuildFromRawCommandAsync = exports.easBuild = exports.runCommand = exports.projectOwner = exports.authenticate = exports.parseCommand = exports.appPlatformEmojis = exports.appPlatformDisplayNames = exports.BuildStatus = exports.AppPlatform = void 0;
 const core_1 = __nccwpck_require__(2186);
 const exec_1 = __nccwpck_require__(1514);
 const io_1 = __nccwpck_require__(7436);
@@ -38711,6 +38711,16 @@ var AppPlatform;
     AppPlatform["Android"] = "ANDROID";
     AppPlatform["Ios"] = "IOS";
 })(AppPlatform || (exports.AppPlatform = AppPlatform = {}));
+var BuildStatus;
+(function (BuildStatus) {
+    BuildStatus["New"] = "NEW";
+    BuildStatus["InQueue"] = "IN_QUEUE";
+    BuildStatus["InProgress"] = "IN_PROGRESS";
+    BuildStatus["PendingCancel"] = "PENDING_CANCEL";
+    BuildStatus["Errored"] = "ERRORED";
+    BuildStatus["Finished"] = "FINISHED";
+    BuildStatus["Canceled"] = "CANCELED";
+})(BuildStatus || (exports.BuildStatus = BuildStatus = {}));
 exports.appPlatformDisplayNames = {
     [AppPlatform.Android]: 'Android',
     [AppPlatform.Ios]: 'iOS',

--- a/build/preview-build/index.js
+++ b/build/preview-build/index.js
@@ -89299,7 +89299,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getBuildLogsUrl = exports.projectDeepLink = exports.projectLink = exports.projectQR = exports.projectAppType = exports.projectInfo = exports.queryEasBuildInfoAsync = exports.cancelEasBuildAsync = exports.createEasBuildFromRawCommandAsync = exports.easBuild = exports.runCommand = exports.projectOwner = exports.authenticate = exports.parseCommand = exports.appPlatformEmojis = exports.appPlatformDisplayNames = exports.AppPlatform = void 0;
+exports.getBuildLogsUrl = exports.projectDeepLink = exports.projectLink = exports.projectQR = exports.projectAppType = exports.projectInfo = exports.queryEasBuildInfoAsync = exports.cancelEasBuildAsync = exports.createEasBuildFromRawCommandAsync = exports.easBuild = exports.runCommand = exports.projectOwner = exports.authenticate = exports.parseCommand = exports.appPlatformEmojis = exports.appPlatformDisplayNames = exports.BuildStatus = exports.AppPlatform = void 0;
 const core_1 = __nccwpck_require__(2186);
 const exec_1 = __nccwpck_require__(1514);
 const io_1 = __nccwpck_require__(7436);
@@ -89311,6 +89311,16 @@ var AppPlatform;
     AppPlatform["Android"] = "ANDROID";
     AppPlatform["Ios"] = "IOS";
 })(AppPlatform || (exports.AppPlatform = AppPlatform = {}));
+var BuildStatus;
+(function (BuildStatus) {
+    BuildStatus["New"] = "NEW";
+    BuildStatus["InQueue"] = "IN_QUEUE";
+    BuildStatus["InProgress"] = "IN_PROGRESS";
+    BuildStatus["PendingCancel"] = "PENDING_CANCEL";
+    BuildStatus["Errored"] = "ERRORED";
+    BuildStatus["Finished"] = "FINISHED";
+    BuildStatus["Canceled"] = "CANCELED";
+})(BuildStatus || (exports.BuildStatus = BuildStatus = {}));
 exports.appPlatformDisplayNames = {
     [AppPlatform.Android]: 'Android',
     [AppPlatform.Ios]: 'iOS',

--- a/build/preview-comment/index.js
+++ b/build/preview-comment/index.js
@@ -38643,7 +38643,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getBuildLogsUrl = exports.projectDeepLink = exports.projectLink = exports.projectQR = exports.projectAppType = exports.projectInfo = exports.queryEasBuildInfoAsync = exports.cancelEasBuildAsync = exports.createEasBuildFromRawCommandAsync = exports.easBuild = exports.runCommand = exports.projectOwner = exports.authenticate = exports.parseCommand = exports.appPlatformEmojis = exports.appPlatformDisplayNames = exports.AppPlatform = void 0;
+exports.getBuildLogsUrl = exports.projectDeepLink = exports.projectLink = exports.projectQR = exports.projectAppType = exports.projectInfo = exports.queryEasBuildInfoAsync = exports.cancelEasBuildAsync = exports.createEasBuildFromRawCommandAsync = exports.easBuild = exports.runCommand = exports.projectOwner = exports.authenticate = exports.parseCommand = exports.appPlatformEmojis = exports.appPlatformDisplayNames = exports.BuildStatus = exports.AppPlatform = void 0;
 const core_1 = __nccwpck_require__(2186);
 const exec_1 = __nccwpck_require__(1514);
 const io_1 = __nccwpck_require__(7436);
@@ -38655,6 +38655,16 @@ var AppPlatform;
     AppPlatform["Android"] = "ANDROID";
     AppPlatform["Ios"] = "IOS";
 })(AppPlatform || (exports.AppPlatform = AppPlatform = {}));
+var BuildStatus;
+(function (BuildStatus) {
+    BuildStatus["New"] = "NEW";
+    BuildStatus["InQueue"] = "IN_QUEUE";
+    BuildStatus["InProgress"] = "IN_PROGRESS";
+    BuildStatus["PendingCancel"] = "PENDING_CANCEL";
+    BuildStatus["Errored"] = "ERRORED";
+    BuildStatus["Finished"] = "FINISHED";
+    BuildStatus["Canceled"] = "CANCELED";
+})(BuildStatus || (exports.BuildStatus = BuildStatus = {}));
 exports.appPlatformDisplayNames = {
     [AppPlatform.Android]: 'Android',
     [AppPlatform.Ios]: 'iOS',

--- a/build/preview/index.js
+++ b/build/preview/index.js
@@ -42176,7 +42176,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getBuildLogsUrl = exports.projectDeepLink = exports.projectLink = exports.projectQR = exports.projectAppType = exports.projectInfo = exports.queryEasBuildInfoAsync = exports.cancelEasBuildAsync = exports.createEasBuildFromRawCommandAsync = exports.easBuild = exports.runCommand = exports.projectOwner = exports.authenticate = exports.parseCommand = exports.appPlatformEmojis = exports.appPlatformDisplayNames = exports.AppPlatform = void 0;
+exports.getBuildLogsUrl = exports.projectDeepLink = exports.projectLink = exports.projectQR = exports.projectAppType = exports.projectInfo = exports.queryEasBuildInfoAsync = exports.cancelEasBuildAsync = exports.createEasBuildFromRawCommandAsync = exports.easBuild = exports.runCommand = exports.projectOwner = exports.authenticate = exports.parseCommand = exports.appPlatformEmojis = exports.appPlatformDisplayNames = exports.BuildStatus = exports.AppPlatform = void 0;
 const core_1 = __nccwpck_require__(2186);
 const exec_1 = __nccwpck_require__(1514);
 const io_1 = __nccwpck_require__(7436);
@@ -42188,6 +42188,16 @@ var AppPlatform;
     AppPlatform["Android"] = "ANDROID";
     AppPlatform["Ios"] = "IOS";
 })(AppPlatform || (exports.AppPlatform = AppPlatform = {}));
+var BuildStatus;
+(function (BuildStatus) {
+    BuildStatus["New"] = "NEW";
+    BuildStatus["InQueue"] = "IN_QUEUE";
+    BuildStatus["InProgress"] = "IN_PROGRESS";
+    BuildStatus["PendingCancel"] = "PENDING_CANCEL";
+    BuildStatus["Errored"] = "ERRORED";
+    BuildStatus["Finished"] = "FINISHED";
+    BuildStatus["Canceled"] = "CANCELED";
+})(BuildStatus || (exports.BuildStatus = BuildStatus = {}));
 exports.appPlatformDisplayNames = {
     [AppPlatform.Android]: 'Android',
     [AppPlatform.Ios]: 'iOS',

--- a/build/setup/index.js
+++ b/build/setup/index.js
@@ -88920,7 +88920,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getBuildLogsUrl = exports.projectDeepLink = exports.projectLink = exports.projectQR = exports.projectAppType = exports.projectInfo = exports.queryEasBuildInfoAsync = exports.cancelEasBuildAsync = exports.createEasBuildFromRawCommandAsync = exports.easBuild = exports.runCommand = exports.projectOwner = exports.authenticate = exports.parseCommand = exports.appPlatformEmojis = exports.appPlatformDisplayNames = exports.AppPlatform = void 0;
+exports.getBuildLogsUrl = exports.projectDeepLink = exports.projectLink = exports.projectQR = exports.projectAppType = exports.projectInfo = exports.queryEasBuildInfoAsync = exports.cancelEasBuildAsync = exports.createEasBuildFromRawCommandAsync = exports.easBuild = exports.runCommand = exports.projectOwner = exports.authenticate = exports.parseCommand = exports.appPlatformEmojis = exports.appPlatformDisplayNames = exports.BuildStatus = exports.AppPlatform = void 0;
 const core_1 = __nccwpck_require__(2186);
 const exec_1 = __nccwpck_require__(1514);
 const io_1 = __nccwpck_require__(7436);
@@ -88932,6 +88932,16 @@ var AppPlatform;
     AppPlatform["Android"] = "ANDROID";
     AppPlatform["Ios"] = "IOS";
 })(AppPlatform || (exports.AppPlatform = AppPlatform = {}));
+var BuildStatus;
+(function (BuildStatus) {
+    BuildStatus["New"] = "NEW";
+    BuildStatus["InQueue"] = "IN_QUEUE";
+    BuildStatus["InProgress"] = "IN_PROGRESS";
+    BuildStatus["PendingCancel"] = "PENDING_CANCEL";
+    BuildStatus["Errored"] = "ERRORED";
+    BuildStatus["Finished"] = "FINISHED";
+    BuildStatus["Canceled"] = "CANCELED";
+})(BuildStatus || (exports.BuildStatus = BuildStatus = {}));
 exports.appPlatformDisplayNames = {
     [AppPlatform.Android]: 'Android',
     [AppPlatform.Ios]: 'iOS',

--- a/src/expo.ts
+++ b/src/expo.ts
@@ -25,6 +25,16 @@ export enum AppPlatform {
   Ios = 'IOS',
 }
 
+export enum BuildStatus {
+  New = 'NEW',
+  InQueue = 'IN_QUEUE',
+  InProgress = 'IN_PROGRESS',
+  PendingCancel = 'PENDING_CANCEL',
+  Errored = 'ERRORED',
+  Finished = 'FINISHED',
+  Canceled = 'CANCELED',
+}
+
 export type BuildInfo = {
   id: string;
   platform: AppPlatform;
@@ -43,6 +53,7 @@ export type BuildInfo = {
   appVersion: string;
   gitCommitHash: string;
   expirationDate: string;
+  status: BuildStatus;
 };
 
 export const appPlatformDisplayNames: Record<AppPlatform, string> = {


### PR DESCRIPTION
### Linked issue

Closes ENG-13414.
Closes #301.

### Additional context

This changes the filtering to include all in-progress and successful statuses so subsequent runs of the workflow for the same runtime version don't trigger a new build if one is already in progress.
