### PR TITLE
[continuous-deploy-fingeprint] Output whether each platform build was created or one was reused

### DIFF
--- a/continuous-deploy-fingerprint/action.yml
+++ b/continuous-deploy-fingerprint/action.yml
@@ -30,8 +30,12 @@ outputs:
   ios-fingerprint:
     description: The iOS fingerprint of the current commit.
   android-build-id:
-    description: ID for Android EAS Build if one was started
+    description: ID for Android EAS Build with matching fingerprint.
+  android-did-start-new-build:
+    description: Whether this run of the action started a new Android EAS Build.
   ios-build-id:
-    description: ID for iOS EAS Build if one was started.
+    description: ID for iOS EAS Build with matching fingerprint.
+  ios-did-start-new-build:
+    description: Whether this run of the action started a new iOS EAS Build.
   update-output:
     description: The output (JSON) from the `eas update` command


### PR DESCRIPTION
### Linked issue

Closes #290.
Closes ENG-13543.

### Additional context

Showing whether the run of the action started a new build can be useful for next steps in the workflow. This makes this change and outputs the info and does some slight refactors to make things more type safe.
