### PR TITLE
fix(continuous-deploy-fingerprint): correct expiration date logic for build validation

### DIFF
--- a/build/continuous-deploy-fingerprint/index.js
+++ b/build/continuous-deploy-fingerprint/index.js
@@ -44667,7 +44667,7 @@ async function getBuildInfoWithFingerprintAsync({ cwd, platform, profile, finger
     const buildsThatAreValid = builds.filter(build => {
         const isValidStatus = [expo_1.BuildStatus.New, expo_1.BuildStatus.InQueue, expo_1.BuildStatus.InProgress, expo_1.BuildStatus.Finished].includes(build.status);
         // if the build is expired or will expire within the next day,
-        const isValidExpiry = excludeExpiredBuilds ? new Date(build.expirationDate) < tomorrow : true;
+        const isValidExpiry = excludeExpiredBuilds ? new Date(build.expirationDate) > tomorrow : true;
         return isValidStatus && isValidExpiry;
     });
     return buildsThatAreValid[0] ?? null;

--- a/src/actions/continuous-deploy-fingerprint.ts
+++ b/src/actions/continuous-deploy-fingerprint.ts
@@ -183,7 +183,7 @@ async function getBuildInfoWithFingerprintAsync({
       build.status
     );
     // if the build is expired or will expire within the next day,
-    const isValidExpiry = excludeExpiredBuilds ? new Date(build.expirationDate) < tomorrow : true;
+    const isValidExpiry = excludeExpiredBuilds ? new Date(build.expirationDate) > tomorrow : true;
     return isValidStatus && isValidExpiry;
   });
 


### PR DESCRIPTION
This commit fixes the logic for validating build expiration dates in the continuous deployment fingerprint process. The condition was incorrectly set to exclude builds that expire after tomorrow, when it should have been excluding builds that expire before tomorrow.

### Linked issue

https://github.com/expo/expo-github-action/pull/303

