### PR TITLE
Fix preview action throwing an error when `qr-target: dev-build` is used

### DIFF
--- a/src/actions/preview.ts
+++ b/src/actions/preview.ts
@@ -18,7 +18,7 @@ export const MESSAGE_ID = 'projectId:{projectId}';
 
 export function previewInput() {
   const qrTarget = getInput('qr-target') || undefined;
-  if (qrTarget && !['expo-go', 'dev-client'].includes(qrTarget)) {
+  if (qrTarget && !['expo-go', 'dev-build', 'dev-client'].includes(qrTarget)) {
     throw new Error(`Invalid QR code target: "${qrTarget}", expected "expo-go" or "dev-build"`);
   }
 


### PR DESCRIPTION
### Linked issue
https://github.com/expo/expo-github-action/issues/311