### PR TITLE
[preview] Use the config scheme for QR code

### DIFF
--- a/src/__tests__/eas.test.ts
+++ b/src/__tests__/eas.test.ts
@@ -12,7 +12,7 @@ describe(getUpdateGroupQr, () => {
     ).toBe('https://qr.expo.dev/eas-update?projectId=projectId&groupId=updateGroupId');
   });
 
-  it('returns url for dev-build', () => {
+  it('returns url for dev-build with appSlug fallback', () => {
     expect(
       getUpdateGroupQr({
         qrTarget: 'dev-build',
@@ -25,7 +25,21 @@ describe(getUpdateGroupQr, () => {
     );
   });
 
-  it('returns url for dev-build, with `_` in appSlug', () => {
+  it('returns url for dev-build with projectScheme', () => {
+    expect(
+      getUpdateGroupQr({
+        qrTarget: 'dev-build',
+        projectId: 'projectId',
+        updateGroupId: 'updateGroupId',
+        appSlug: 'appslug',
+        projectScheme: 'myscheme',
+      })
+    ).toBe(
+      'https://qr.expo.dev/eas-update?appScheme=myscheme&projectId=projectId&groupId=updateGroupId'
+    );
+  });
+
+  it('returns url for dev-build, with `_` in appSlug fallback', () => {
     expect(
       getUpdateGroupQr({
         qrTarget: 'dev-build',
@@ -35,6 +49,20 @@ describe(getUpdateGroupQr, () => {
       })
     ).toBe(
       'https://qr.expo.dev/eas-update?appScheme=helloworld&projectId=projectId&groupId=updateGroupId'
+    );
+  });
+
+  it('returns url for dev-build, with `_` in projectScheme', () => {
+    expect(
+      getUpdateGroupQr({
+        qrTarget: 'dev-build',
+        projectId: 'projectId',
+        updateGroupId: 'updateGroupId',
+        appSlug: 'hello_world',
+        projectScheme: 'my_custom_scheme',
+      })
+    ).toBe(
+      'https://qr.expo.dev/eas-update?appScheme=mycustomscheme&projectId=projectId&groupId=updateGroupId'
     );
   });
 });

--- a/src/actions/preview.ts
+++ b/src/actions/preview.ts
@@ -121,6 +121,7 @@ export function getVariables(
   const ios = updates.find(update => update.platform === 'ios');
 
   const appSchemes = getSchemesInOrderFromConfig(config) || [];
+  const projectScheme = appSchemes[0] || ''; // This is the longest scheme from one or more custom app schemes
   const appSlug = config.slug;
   const qrTarget = getQrTarget(options);
 
@@ -129,13 +130,13 @@ export function getVariables(
     projectId,
     projectName: config.name,
     projectSlug: appSlug,
-    projectScheme: appSchemes[0] || '', // This is the longest scheme from one or more custom app schemes
+    projectScheme,
     projectSchemes: JSON.stringify(appSchemes), // These are all custom app schemes, in order from longest to shortest as JSON
     // Shared update properties
     // Note, only use these properties when the update groups are identical
     groupId: updates[0].group,
     runtimeVersion: updates[0].runtimeVersion,
-    qr: getUpdateGroupQr({ projectId, updateGroupId: updates[0].group, appSlug, qrTarget }),
+    qr: getUpdateGroupQr({ projectId, updateGroupId: updates[0].group, appSlug, projectScheme, qrTarget }),
     link: getUpdateGroupWebsite({ projectId, updateGroupId: updates[0].group }),
     // These are safe to access regardless of the update groups
     branchName: updates[0].branch,
@@ -150,7 +151,7 @@ export function getVariables(
     androidMessage: android?.message || '',
     androidRuntimeVersion: android?.runtimeVersion || '',
     androidQR: android
-      ? getUpdateGroupQr({ projectId, updateGroupId: android.group, appSlug, qrTarget })
+      ? getUpdateGroupQr({ projectId, updateGroupId: android.group, appSlug, projectScheme, qrTarget })
       : '',
     androidLink: android ? getUpdateGroupWebsite({ projectId, updateGroupId: android.group }) : '',
     // iOS update
@@ -160,7 +161,7 @@ export function getVariables(
     iosManifestPermalink: ios?.manifestPermalink || '',
     iosMessage: ios?.message || '',
     iosRuntimeVersion: ios?.runtimeVersion || '',
-    iosQR: ios ? getUpdateGroupQr({ projectId, updateGroupId: ios.group, appSlug, qrTarget }) : '',
+    iosQR: ios ? getUpdateGroupQr({ projectId, updateGroupId: ios.group, appSlug, projectScheme, qrTarget }) : '',
     iosLink: ios ? getUpdateGroupWebsite({ projectId, updateGroupId: ios.group }) : '',
   };
 }

--- a/src/eas.ts
+++ b/src/eas.ts
@@ -74,20 +74,23 @@ export function getUpdateGroupQr({
   projectId,
   updateGroupId,
   appSlug,
+  projectScheme,
   qrTarget,
 }: {
   projectId: string;
   updateGroupId: string;
   appSlug: string;
+  projectScheme?: string;
   qrTarget: 'expo-go' | 'dev-build';
 }): string {
   const url = new URL('https://qr.expo.dev/eas-update');
 
   if (qrTarget === 'dev-build') {
-    // While the parameter is called `appScheme`, it's actually the app's slug
+    // Use the project scheme from config if available, otherwise fall back to appSlug
     // This should only be added when using dev clients as target
     // See: https://github.com/expo/expo/blob/8ae75dde393e5d2393d446227a1fe2482c75eec3/packages/expo-dev-client/plugin/src/getDefaultScheme.ts#L17
-    url.searchParams.append('appScheme', appSlug.replace(/[^A-Za-z0-9+\-.]/g, ''));
+    const scheme = projectScheme || appSlug;
+    url.searchParams.append('appScheme', scheme.replace(/[^A-Za-z0-9+\-.]/g, ''));
   }
 
   if (process.env.EXPO_STAGING) {


### PR DESCRIPTION
The github comment includes the scheme, so it's unexpected if the QR
code uses a different scheme to open the dev client
