### PR TITLE
fix(preview): use project scheme instead of slug for dev-build QR codes

### DIFF
--- a/build/continuous-deploy-fingerprint/index.js
+++ b/build/continuous-deploy-fingerprint/index.js
@@ -34859,13 +34859,10 @@ async function createUpdate(cwd, command) {
 /**
  * Create a QR code link for an EAS Update.
  */
-function getUpdateGroupQr({ projectId, updateGroupId, appSlug, qrTarget, }) {
+function getUpdateGroupQr({ projectId, updateGroupId, appScheme, qrTarget, }) {
     const url = new url_1.URL('https://qr.expo.dev/eas-update');
     if (qrTarget === 'dev-build') {
-        // While the parameter is called `appScheme`, it's actually the app's slug
-        // This should only be added when using dev clients as target
-        // See: https://github.com/expo/expo/blob/8ae75dde393e5d2393d446227a1fe2482c75eec3/packages/expo-dev-client/plugin/src/getDefaultScheme.ts#L17
-        url.searchParams.append('appScheme', appSlug.replace(/[^A-Za-z0-9+\-.]/g, ''));
+        url.searchParams.append('appScheme', appScheme.replace(/[^A-Za-z0-9+\-.]/g, ''));
     }
     if (process.env.EXPO_STAGING) {
         url.searchParams.append('host', 'staging-u.expo.dev');
@@ -37700,6 +37697,7 @@ function createSummaryForUpdatesAndBuilds({ config, projectId, updates, buildRun
     const appSlug = config.slug;
     const qrTarget = (0, comment_1.getQrTarget)(options);
     const appSchemes = (0, comment_1.getSchemesInOrderFromConfig)(config) || [];
+    const appScheme = appSchemes[0] || appSlug;
     const { androidBuildRunInfo, iosBuildRunInfo } = buildRunInfos;
     const androidUpdate = updates.find(update => update.platform === 'android');
     const iosUpdate = updates.find(update => update.platform === 'ios');
@@ -37707,7 +37705,9 @@ function createSummaryForUpdatesAndBuilds({ config, projectId, updates, buildRun
     const getUpdateLink = (update) => update
         ? `[Update Permalink](${(0, eas_1.getUpdateGroupWebsite)({ projectId, updateGroupId: update.group })})`
         : 'n/a';
-    const getUpdateQRURL = (update) => update ? (0, eas_1.getUpdateGroupQr)({ projectId, updateGroupId: update.group, appSlug, qrTarget }) : null;
+    const getUpdateQRURL = (update) => update
+        ? (0, eas_1.getUpdateGroupQr)({ projectId, updateGroupId: update.group, appScheme, qrTarget })
+        : null;
     const getBuildDetails = (buildRunInfo) => getBuildLink(buildRunInfo.buildInfo) +
         '<br />' +
         (0, comment_1.createDetails)({

--- a/build/preview/index.js
+++ b/build/preview/index.js
@@ -34859,6 +34859,7 @@ function getVariables(config, updates, options) {
     const ios = updates.find(update => update.platform === 'ios');
     const appSchemes = (0, comment_1.getSchemesInOrderFromConfig)(config) || [];
     const appSlug = config.slug;
+    const appScheme = appSchemes[0] || appSlug;
     const qrTarget = (0, comment_1.getQrTarget)(options);
     return {
         // EAS / Expo specific
@@ -34871,7 +34872,7 @@ function getVariables(config, updates, options) {
         // Note, only use these properties when the update groups are identical
         groupId: updates[0].group,
         runtimeVersion: updates[0].runtimeVersion,
-        qr: (0, eas_1.getUpdateGroupQr)({ projectId, updateGroupId: updates[0].group, appSlug, qrTarget }),
+        qr: (0, eas_1.getUpdateGroupQr)({ projectId, updateGroupId: updates[0].group, appScheme, qrTarget }),
         link: (0, eas_1.getUpdateGroupWebsite)({ projectId, updateGroupId: updates[0].group }),
         // These are safe to access regardless of the update groups
         branchName: updates[0].branch,
@@ -34886,7 +34887,7 @@ function getVariables(config, updates, options) {
         androidMessage: android?.message || '',
         androidRuntimeVersion: android?.runtimeVersion || '',
         androidQR: android
-            ? (0, eas_1.getUpdateGroupQr)({ projectId, updateGroupId: android.group, appSlug, qrTarget })
+            ? (0, eas_1.getUpdateGroupQr)({ projectId, updateGroupId: android.group, appScheme, qrTarget })
             : '',
         androidLink: android ? (0, eas_1.getUpdateGroupWebsite)({ projectId, updateGroupId: android.group }) : '',
         // iOS update
@@ -34896,7 +34897,9 @@ function getVariables(config, updates, options) {
         iosManifestPermalink: ios?.manifestPermalink || '',
         iosMessage: ios?.message || '',
         iosRuntimeVersion: ios?.runtimeVersion || '',
-        iosQR: ios ? (0, eas_1.getUpdateGroupQr)({ projectId, updateGroupId: ios.group, appSlug, qrTarget }) : '',
+        iosQR: ios
+            ? (0, eas_1.getUpdateGroupQr)({ projectId, updateGroupId: ios.group, appScheme, qrTarget })
+            : '',
         iosLink: ios ? (0, eas_1.getUpdateGroupWebsite)({ projectId, updateGroupId: ios.group }) : '',
     };
 }
@@ -35071,13 +35074,10 @@ async function createUpdate(cwd, command) {
 /**
  * Create a QR code link for an EAS Update.
  */
-function getUpdateGroupQr({ projectId, updateGroupId, appSlug, qrTarget, }) {
+function getUpdateGroupQr({ projectId, updateGroupId, appScheme, qrTarget, }) {
     const url = new url_1.URL('https://qr.expo.dev/eas-update');
     if (qrTarget === 'dev-build') {
-        // While the parameter is called `appScheme`, it's actually the app's slug
-        // This should only be added when using dev clients as target
-        // See: https://github.com/expo/expo/blob/8ae75dde393e5d2393d446227a1fe2482c75eec3/packages/expo-dev-client/plugin/src/getDefaultScheme.ts#L17
-        url.searchParams.append('appScheme', appSlug.replace(/[^A-Za-z0-9+\-.]/g, ''));
+        url.searchParams.append('appScheme', appScheme.replace(/[^A-Za-z0-9+\-.]/g, ''));
     }
     if (process.env.EXPO_STAGING) {
         url.searchParams.append('host', 'staging-u.expo.dev');

--- a/src/__tests__/actions/preview.test.ts
+++ b/src/__tests__/actions/preview.test.ts
@@ -9,6 +9,10 @@ const fakeOptions = {
   qrTarget: 'dev-client',
 } as unknown as ReturnType<typeof previewInput>;
 
+const fakeExpoGoOptions = {
+  qrTarget: 'expo-go',
+} as unknown as ReturnType<typeof previewInput>;
+
 const fakeExpoConfig = {
   slug: 'fake-project',
   extra: {
@@ -45,6 +49,74 @@ const fakeUpdatesMultiple = fakeUpdatesSingle.map(update => ({
   ...update,
   group: `fake-group-${update.id}`,
 }));
+
+describe(getVariables, () => {
+  describe('QR code scheme selection', () => {
+    it('uses custom scheme for dev-build QR code when scheme is defined', () => {
+      const configWithScheme = {
+        ...fakeExpoConfig,
+        scheme: ['myappdev', 'myapp'],
+      } as unknown as ExpoConfig;
+
+      const variables = getVariables(configWithScheme, fakeUpdatesSingle, fakeOptions);
+
+      // Should use the first (longest) scheme, not the slug
+      expect(variables.qr).toContain('appScheme=myappdev');
+      expect(variables.qr).not.toContain('appScheme=fake-project');
+      expect(variables.androidQR).toContain('appScheme=myappdev');
+      expect(variables.iosQR).toContain('appScheme=myappdev');
+    });
+
+    it('falls back to slug for dev-build QR code when no scheme is defined', () => {
+      const configWithoutScheme = {
+        ...fakeExpoConfig,
+        scheme: undefined,
+      } as unknown as ExpoConfig;
+
+      const variables = getVariables(configWithoutScheme, fakeUpdatesSingle, fakeOptions);
+
+      // Should fallback to slug when no scheme is defined
+      expect(variables.qr).toContain('appScheme=fake-project');
+      expect(variables.androidQR).toContain('appScheme=fake-project');
+      expect(variables.iosQR).toContain('appScheme=fake-project');
+    });
+
+    it('falls back to slug for dev-build QR code when scheme array is empty', () => {
+      const configWithEmptyScheme = {
+        ...fakeExpoConfig,
+        scheme: [],
+      } as unknown as ExpoConfig;
+
+      const variables = getVariables(configWithEmptyScheme, fakeUpdatesSingle, fakeOptions);
+
+      // Should fallback to slug when scheme array is empty
+      expect(variables.qr).toContain('appScheme=fake-project');
+    });
+
+    it('does not include appScheme in QR code for expo-go target', () => {
+      const configWithScheme = {
+        ...fakeExpoConfig,
+        scheme: ['myappdev'],
+      } as unknown as ExpoConfig;
+
+      const variables = getVariables(configWithScheme, fakeUpdatesSingle, fakeExpoGoOptions);
+
+      // expo-go target should not have appScheme parameter
+      expect(variables.qr).not.toContain('appScheme=');
+    });
+
+    it('uses single string scheme for dev-build QR code', () => {
+      const configWithStringScheme = {
+        ...fakeExpoConfig,
+        scheme: 'singlescheme',
+      } as unknown as ExpoConfig;
+
+      const variables = getVariables(configWithStringScheme, fakeUpdatesSingle, fakeOptions);
+
+      expect(variables.qr).toContain('appScheme=singlescheme');
+    });
+  });
+});
 
 describe(createSummary, () => {
   describe('single update group', () => {
@@ -84,7 +156,7 @@ describe(createSummary, () => {
         - Runtime Version → **exposdk:47.0.0**
         - **[More info](https://expo.dev/projects/fake-project-id/updates/fake-group-id)**
 
-        <a href="https://qr.expo.dev/eas-update?appScheme=fake-project&projectId=fake-project-id&groupId=fake-group-id"><img src="https://qr.expo.dev/eas-update?appScheme=fake-project&projectId=fake-project-id&groupId=fake-group-id" width="250px" height="250px" /></a>
+        <a href="https://qr.expo.dev/eas-update?appScheme=expogithubaction&projectId=fake-project-id&groupId=fake-group-id"><img src="https://qr.expo.dev/eas-update?appScheme=expogithubaction&projectId=fake-project-id&groupId=fake-group-id" width="250px" height="250px" /></a>
 
         > Learn more about [𝝠 Expo Github Action](https://github.com/expo/expo-github-action/tree/main/preview#example-workflows)"
       `);

--- a/src/__tests__/eas.test.ts
+++ b/src/__tests__/eas.test.ts
@@ -7,7 +7,7 @@ describe(getUpdateGroupQr, () => {
         qrTarget: 'expo-go',
         projectId: 'projectId',
         updateGroupId: 'updateGroupId',
-        appSlug: 'appslug',
+        appScheme: 'appslug',
       })
     ).toBe('https://qr.expo.dev/eas-update?projectId=projectId&groupId=updateGroupId');
   });
@@ -18,20 +18,20 @@ describe(getUpdateGroupQr, () => {
         qrTarget: 'dev-build',
         projectId: 'projectId',
         updateGroupId: 'updateGroupId',
-        appSlug: 'appslug',
+        appScheme: 'appscheme',
       })
     ).toBe(
-      'https://qr.expo.dev/eas-update?appScheme=appslug&projectId=projectId&groupId=updateGroupId'
+      'https://qr.expo.dev/eas-update?appScheme=appscheme&projectId=projectId&groupId=updateGroupId'
     );
   });
 
-  it('returns url for dev-build, with `_` in appSlug', () => {
+  it('returns url for dev-build, with `_` in appScheme', () => {
     expect(
       getUpdateGroupQr({
         qrTarget: 'dev-build',
         projectId: 'projectId',
         updateGroupId: 'updateGroupId',
-        appSlug: 'hello_world',
+        appScheme: 'hello_world',
       })
     ).toBe(
       'https://qr.expo.dev/eas-update?appScheme=helloworld&projectId=projectId&groupId=updateGroupId'

--- a/src/actions/continuous-deploy-fingerprint.ts
+++ b/src/actions/continuous-deploy-fingerprint.ts
@@ -261,6 +261,7 @@ function createSummaryForUpdatesAndBuilds({
   const appSlug = config.slug;
   const qrTarget = getQrTarget(options);
   const appSchemes = getSchemesInOrderFromConfig(config) || [];
+  const appScheme = appSchemes[0] || appSlug;
 
   const { androidBuildRunInfo, iosBuildRunInfo } = buildRunInfos;
 
@@ -274,7 +275,9 @@ function createSummaryForUpdatesAndBuilds({
       ? `[Update Permalink](${getUpdateGroupWebsite({ projectId, updateGroupId: update.group })})`
       : 'n/a';
   const getUpdateQRURL = (update: EasUpdate | undefined) =>
-    update ? getUpdateGroupQr({ projectId, updateGroupId: update.group, appSlug, qrTarget }) : null;
+    update
+      ? getUpdateGroupQr({ projectId, updateGroupId: update.group, appScheme, qrTarget })
+      : null;
   const getBuildDetails = (buildRunInfo: BuildRunInfo) =>
     getBuildLink(buildRunInfo.buildInfo) +
     '<br />' +

--- a/src/actions/preview.ts
+++ b/src/actions/preview.ts
@@ -122,6 +122,7 @@ export function getVariables(
 
   const appSchemes = getSchemesInOrderFromConfig(config) || [];
   const appSlug = config.slug;
+  const appScheme = appSchemes[0] || appSlug;
   const qrTarget = getQrTarget(options);
 
   return {
@@ -135,7 +136,7 @@ export function getVariables(
     // Note, only use these properties when the update groups are identical
     groupId: updates[0].group,
     runtimeVersion: updates[0].runtimeVersion,
-    qr: getUpdateGroupQr({ projectId, updateGroupId: updates[0].group, appSlug, qrTarget }),
+    qr: getUpdateGroupQr({ projectId, updateGroupId: updates[0].group, appScheme, qrTarget }),
     link: getUpdateGroupWebsite({ projectId, updateGroupId: updates[0].group }),
     // These are safe to access regardless of the update groups
     branchName: updates[0].branch,
@@ -150,7 +151,7 @@ export function getVariables(
     androidMessage: android?.message || '',
     androidRuntimeVersion: android?.runtimeVersion || '',
     androidQR: android
-      ? getUpdateGroupQr({ projectId, updateGroupId: android.group, appSlug, qrTarget })
+      ? getUpdateGroupQr({ projectId, updateGroupId: android.group, appScheme, qrTarget })
       : '',
     androidLink: android ? getUpdateGroupWebsite({ projectId, updateGroupId: android.group }) : '',
     // iOS update
@@ -160,7 +161,9 @@ export function getVariables(
     iosManifestPermalink: ios?.manifestPermalink || '',
     iosMessage: ios?.message || '',
     iosRuntimeVersion: ios?.runtimeVersion || '',
-    iosQR: ios ? getUpdateGroupQr({ projectId, updateGroupId: ios.group, appSlug, qrTarget }) : '',
+    iosQR: ios
+      ? getUpdateGroupQr({ projectId, updateGroupId: ios.group, appScheme, qrTarget })
+      : '',
     iosLink: ios ? getUpdateGroupWebsite({ projectId, updateGroupId: ios.group }) : '',
   };
 }

--- a/src/eas.ts
+++ b/src/eas.ts
@@ -73,21 +73,18 @@ export async function createUpdate(cwd: string, command: string): Promise<EasUpd
 export function getUpdateGroupQr({
   projectId,
   updateGroupId,
-  appSlug,
+  appScheme,
   qrTarget,
 }: {
   projectId: string;
   updateGroupId: string;
-  appSlug: string;
+  appScheme: string;
   qrTarget: 'expo-go' | 'dev-build';
 }): string {
   const url = new URL('https://qr.expo.dev/eas-update');
 
   if (qrTarget === 'dev-build') {
-    // While the parameter is called `appScheme`, it's actually the app's slug
-    // This should only be added when using dev clients as target
-    // See: https://github.com/expo/expo/blob/8ae75dde393e5d2393d446227a1fe2482c75eec3/packages/expo-dev-client/plugin/src/getDefaultScheme.ts#L17
-    url.searchParams.append('appScheme', appSlug.replace(/[^A-Za-z0-9+\-.]/g, ''));
+    url.searchParams.append('appScheme', appScheme.replace(/[^A-Za-z0-9+\-.]/g, ''));
   }
 
   if (process.env.EXPO_STAGING) {


### PR DESCRIPTION
## Problem

When using the `preview` action with `qr-target: dev-build`, the generated QR code uses the project's slug instead of the custom scheme defined in `app.config.ts`. 

This causes issues when multiple app variants (dev, staging, production) share the same slug but have different `scheme` values — a common setup for teams testing multiple environments on the same device.

**Current behavior:**
// app.config.ts
{ slug: "myapp", scheme: "myappdev" }
// QR code generates: exp+myapp://expo-development-client/...**Expected behavior:**
// app.config.ts
{ slug: "myapp", scheme: "myappdev" }
// QR code generates: myappdev://expo-development-client/...## Solution

- Rename `appSlug` parameter to `appScheme` in `getUpdateGroupQr()` for clarity
- Pass the actual scheme (with fallback to slug) instead of the slug in `getVariables()`
- Apply the same fix to `continuous-deploy-fingerprint` action

## Changes

| File | Change |
|------|--------|
| `src/eas.ts` | Renamed `appSlug` → `appScheme` parameter |
| `src/actions/preview.ts` | Use scheme with slug fallback |
| `src/actions/continuous-deploy-fingerprint.ts` | Use scheme with slug fallback |
| `src/__tests__/eas.test.ts` | Updated test parameters |
| `src/__tests__/actions/preview.test.ts` | Added tests for scheme selection + updated snapshot |

## Testing

With a project using `slug: "froot"` and `scheme: "frootdev"`:

| | QR code scheme |
|---|---|
| **Before fix** | `exp+froot://...` ❌ |
| **After fix** | `frootdev://...` ✅ |

Unit tests added to verify scheme selection behavior.

New unit tests cover:
- ✅ Custom scheme is used when defined
- ✅ Falls back to slug when no scheme is defined
- ✅ Falls back to slug when scheme array is empty
- ✅ expo-go target doesn't include appScheme
- ✅ Single string scheme is supported