### PR TITLE
Add wait-for-build support to preview and continuous deploy actions

### DIFF
--- a/build/command/index.js
+++ b/build/command/index.js
@@ -32333,6 +32333,7 @@ exports.authenticate = authenticate;
 exports.projectOwner = projectOwner;
 exports.runCommand = runCommand;
 exports.easBuild = easBuild;
+exports.getEasBuildWaitArgs = getEasBuildWaitArgs;
 exports.createEasBuildFromRawCommandAsync = createEasBuildFromRawCommandAsync;
 exports.cancelEasBuildAsync = cancelEasBuildAsync;
 exports.queryEasBuildInfoAsync = queryEasBuildInfoAsync;
@@ -32447,19 +32448,29 @@ async function easBuild(cmd) {
     }
     return JSON.parse(stdout);
 }
+function getEasBuildWaitArgs(waitForBuild) {
+    return waitForBuild ? [] : ['--no-wait'];
+}
+function hasEasBuildNoWaitFlag(command) {
+    return /(^|\s)--no-wait(?=\s|$)/.test(command);
+}
 /**
  * Create an new EAS build using the user-provided command.
  */
-async function createEasBuildFromRawCommandAsync(cwd, command, extraArgs = []) {
+async function createEasBuildFromRawCommandAsync(cwd, command, extraArgs = [], options) {
     let stdout = '';
+    const waitForBuild = options?.waitForBuild ?? false;
     let cmd = command;
+    if (waitForBuild && hasEasBuildNoWaitFlag(cmd)) {
+        throw new Error('Cannot use wait-for-build when the EAS build command already includes --no-wait.');
+    }
     if (!cmd.includes('--json')) {
         cmd += ' --json';
     }
     if (!cmd.includes('--non-interactive')) {
         cmd += ' --non-interactive';
     }
-    if (!cmd.includes('--no-wait')) {
+    if (!waitForBuild) {
         cmd += ' --no-wait';
     }
     try {

--- a/build/continuous-deploy-fingerprint-info/index.js
+++ b/build/continuous-deploy-fingerprint-info/index.js
@@ -27937,6 +27937,7 @@ exports.authenticate = authenticate;
 exports.projectOwner = projectOwner;
 exports.runCommand = runCommand;
 exports.easBuild = easBuild;
+exports.getEasBuildWaitArgs = getEasBuildWaitArgs;
 exports.createEasBuildFromRawCommandAsync = createEasBuildFromRawCommandAsync;
 exports.cancelEasBuildAsync = cancelEasBuildAsync;
 exports.queryEasBuildInfoAsync = queryEasBuildInfoAsync;
@@ -28051,19 +28052,29 @@ async function easBuild(cmd) {
     }
     return JSON.parse(stdout);
 }
+function getEasBuildWaitArgs(waitForBuild) {
+    return waitForBuild ? [] : ['--no-wait'];
+}
+function hasEasBuildNoWaitFlag(command) {
+    return /(^|\s)--no-wait(?=\s|$)/.test(command);
+}
 /**
  * Create an new EAS build using the user-provided command.
  */
-async function createEasBuildFromRawCommandAsync(cwd, command, extraArgs = []) {
+async function createEasBuildFromRawCommandAsync(cwd, command, extraArgs = [], options) {
     let stdout = '';
+    const waitForBuild = options?.waitForBuild ?? false;
     let cmd = command;
+    if (waitForBuild && hasEasBuildNoWaitFlag(cmd)) {
+        throw new Error('Cannot use wait-for-build when the EAS build command already includes --no-wait.');
+    }
     if (!cmd.includes('--json')) {
         cmd += ' --json';
     }
     if (!cmd.includes('--non-interactive')) {
         cmd += ' --non-interactive';
     }
-    if (!cmd.includes('--no-wait')) {
+    if (!waitForBuild) {
         cmd += ' --no-wait';
     }
     try {

--- a/build/continuous-deploy-fingerprint/index.js
+++ b/build/continuous-deploy-fingerprint/index.js
@@ -34898,6 +34898,7 @@ exports.authenticate = authenticate;
 exports.projectOwner = projectOwner;
 exports.runCommand = runCommand;
 exports.easBuild = easBuild;
+exports.getEasBuildWaitArgs = getEasBuildWaitArgs;
 exports.createEasBuildFromRawCommandAsync = createEasBuildFromRawCommandAsync;
 exports.cancelEasBuildAsync = cancelEasBuildAsync;
 exports.queryEasBuildInfoAsync = queryEasBuildInfoAsync;
@@ -35012,19 +35013,29 @@ async function easBuild(cmd) {
     }
     return JSON.parse(stdout);
 }
+function getEasBuildWaitArgs(waitForBuild) {
+    return waitForBuild ? [] : ['--no-wait'];
+}
+function hasEasBuildNoWaitFlag(command) {
+    return /(^|\s)--no-wait(?=\s|$)/.test(command);
+}
 /**
  * Create an new EAS build using the user-provided command.
  */
-async function createEasBuildFromRawCommandAsync(cwd, command, extraArgs = []) {
+async function createEasBuildFromRawCommandAsync(cwd, command, extraArgs = [], options) {
     let stdout = '';
+    const waitForBuild = options?.waitForBuild ?? false;
     let cmd = command;
+    if (waitForBuild && hasEasBuildNoWaitFlag(cmd)) {
+        throw new Error('Cannot use wait-for-build when the EAS build command already includes --no-wait.');
+    }
     if (!cmd.includes('--json')) {
         cmd += ' --json';
     }
     if (!cmd.includes('--non-interactive')) {
         cmd += ' --non-interactive';
     }
-    if (!cmd.includes('--no-wait')) {
+    if (!waitForBuild) {
         cmd += ' --no-wait';
     }
     try {
@@ -37541,6 +37552,7 @@ function collectContinuousDeployFingerprintInput() {
         platform: platformInput,
         environment: (0, input_1.getInput)('environment'),
         autoSubmitBuilds: (0, input_1.getInput)('auto-submit-builds') === 'true',
+        waitForBuild: (0, core_1.getBooleanInput)('wait-for-build'),
         githubToken: (0, input_1.getInput)('github-token', { required: true }),
         workingDirectory: (0, input_1.getInput)('working-directory', { required: true }),
     };
@@ -37563,6 +37575,7 @@ async function continuousDeployFingerprintAction(input = collectContinuousDeploy
                 isInPullRequest,
                 environment: input.environment,
                 autoSubmitBuild: input.autoSubmitBuilds,
+                waitForBuild: input.waitForBuild,
             })
             : null,
         platformsToRun.has('ios')
@@ -37573,6 +37586,7 @@ async function continuousDeployFingerprintAction(input = collectContinuousDeploy
                 isInPullRequest,
                 environment: input.environment,
                 autoSubmitBuild: input.autoSubmitBuilds,
+                waitForBuild: input.waitForBuild,
             })
             : null,
     ]);
@@ -37613,7 +37627,7 @@ async function continuousDeployFingerprintAction(input = collectContinuousDeploy
     (0, core_1.setOutput)('ios-did-start-new-build', iosBuildRunInfo?.isNew);
     (0, core_1.setOutput)('update-output', updates);
 }
-async function buildForPlatformIfNecessaryAsync({ platform, workingDirectory, profile, isInPullRequest, environment, autoSubmitBuild, }) {
+async function buildForPlatformIfNecessaryAsync({ platform, workingDirectory, profile, isInPullRequest, environment, autoSubmitBuild, waitForBuild, }) {
     const humanReadablePlatformName = platform === 'ios' ? 'iOS' : 'Android';
     const { buildInfo: existingBuildInfo, fingerprintHash } = await (0, fingerprintUtils_1.getBuildInfoForCurrentFingerprintAsync)({
         workingDirectory,
@@ -37638,13 +37652,14 @@ async function buildForPlatformIfNecessaryAsync({ platform, workingDirectory, pr
                 platform,
                 profile,
                 autoSubmit: autoSubmitBuild,
+                waitForBuild,
             }),
             isNew: true,
             fingerprintHash,
         };
     }
 }
-async function createEASBuildAsync({ cwd, profile, platform, autoSubmit, }) {
+async function createEASBuildAsync({ cwd, profile, platform, autoSubmit, waitForBuild, }) {
     try {
         const extraDebugArgs = (0, core_1.isDebug)() ? ['--build-logger-level', 'debug'] : [];
         const extraAutoSubmitArgs = autoSubmit ? ['--auto-submit'] : [];
@@ -37656,7 +37671,7 @@ async function createEASBuildAsync({ cwd, profile, platform, autoSubmit, }) {
             platform,
             '--non-interactive',
             '--json',
-            '--no-wait',
+            ...(0, expo_1.getEasBuildWaitArgs)(waitForBuild),
             ...extraDebugArgs,
             ...extraAutoSubmitArgs,
         ], {

--- a/build/preview-comment/index.js
+++ b/build/preview-comment/index.js
@@ -32277,6 +32277,7 @@ exports.authenticate = authenticate;
 exports.projectOwner = projectOwner;
 exports.runCommand = runCommand;
 exports.easBuild = easBuild;
+exports.getEasBuildWaitArgs = getEasBuildWaitArgs;
 exports.createEasBuildFromRawCommandAsync = createEasBuildFromRawCommandAsync;
 exports.cancelEasBuildAsync = cancelEasBuildAsync;
 exports.queryEasBuildInfoAsync = queryEasBuildInfoAsync;
@@ -32391,19 +32392,29 @@ async function easBuild(cmd) {
     }
     return JSON.parse(stdout);
 }
+function getEasBuildWaitArgs(waitForBuild) {
+    return waitForBuild ? [] : ['--no-wait'];
+}
+function hasEasBuildNoWaitFlag(command) {
+    return /(^|\s)--no-wait(?=\s|$)/.test(command);
+}
 /**
  * Create an new EAS build using the user-provided command.
  */
-async function createEasBuildFromRawCommandAsync(cwd, command, extraArgs = []) {
+async function createEasBuildFromRawCommandAsync(cwd, command, extraArgs = [], options) {
     let stdout = '';
+    const waitForBuild = options?.waitForBuild ?? false;
     let cmd = command;
+    if (waitForBuild && hasEasBuildNoWaitFlag(cmd)) {
+        throw new Error('Cannot use wait-for-build when the EAS build command already includes --no-wait.');
+    }
     if (!cmd.includes('--json')) {
         cmd += ' --json';
     }
     if (!cmd.includes('--non-interactive')) {
         cmd += ' --non-interactive';
     }
-    if (!cmd.includes('--no-wait')) {
+    if (!waitForBuild) {
         cmd += ' --no-wait';
     }
     try {

--- a/build/preview/index.js
+++ b/build/preview/index.js
@@ -35110,6 +35110,7 @@ exports.authenticate = authenticate;
 exports.projectOwner = projectOwner;
 exports.runCommand = runCommand;
 exports.easBuild = easBuild;
+exports.getEasBuildWaitArgs = getEasBuildWaitArgs;
 exports.createEasBuildFromRawCommandAsync = createEasBuildFromRawCommandAsync;
 exports.cancelEasBuildAsync = cancelEasBuildAsync;
 exports.queryEasBuildInfoAsync = queryEasBuildInfoAsync;
@@ -35224,19 +35225,29 @@ async function easBuild(cmd) {
     }
     return JSON.parse(stdout);
 }
+function getEasBuildWaitArgs(waitForBuild) {
+    return waitForBuild ? [] : ['--no-wait'];
+}
+function hasEasBuildNoWaitFlag(command) {
+    return /(^|\s)--no-wait(?=\s|$)/.test(command);
+}
 /**
  * Create an new EAS build using the user-provided command.
  */
-async function createEasBuildFromRawCommandAsync(cwd, command, extraArgs = []) {
+async function createEasBuildFromRawCommandAsync(cwd, command, extraArgs = [], options) {
     let stdout = '';
+    const waitForBuild = options?.waitForBuild ?? false;
     let cmd = command;
+    if (waitForBuild && hasEasBuildNoWaitFlag(cmd)) {
+        throw new Error('Cannot use wait-for-build when the EAS build command already includes --no-wait.');
+    }
     if (!cmd.includes('--json')) {
         cmd += ' --json';
     }
     if (!cmd.includes('--non-interactive')) {
         cmd += ' --non-interactive';
     }
-    if (!cmd.includes('--no-wait')) {
+    if (!waitForBuild) {
         cmd += ' --no-wait';
     }
     try {

--- a/build/setup/index.js
+++ b/build/setup/index.js
@@ -97991,6 +97991,7 @@ exports.authenticate = authenticate;
 exports.projectOwner = projectOwner;
 exports.runCommand = runCommand;
 exports.easBuild = easBuild;
+exports.getEasBuildWaitArgs = getEasBuildWaitArgs;
 exports.createEasBuildFromRawCommandAsync = createEasBuildFromRawCommandAsync;
 exports.cancelEasBuildAsync = cancelEasBuildAsync;
 exports.queryEasBuildInfoAsync = queryEasBuildInfoAsync;
@@ -98105,19 +98106,29 @@ async function easBuild(cmd) {
     }
     return JSON.parse(stdout);
 }
+function getEasBuildWaitArgs(waitForBuild) {
+    return waitForBuild ? [] : ['--no-wait'];
+}
+function hasEasBuildNoWaitFlag(command) {
+    return /(^|\s)--no-wait(?=\s|$)/.test(command);
+}
 /**
  * Create an new EAS build using the user-provided command.
  */
-async function createEasBuildFromRawCommandAsync(cwd, command, extraArgs = []) {
+async function createEasBuildFromRawCommandAsync(cwd, command, extraArgs = [], options) {
     let stdout = '';
+    const waitForBuild = options?.waitForBuild ?? false;
     let cmd = command;
+    if (waitForBuild && hasEasBuildNoWaitFlag(cmd)) {
+        throw new Error('Cannot use wait-for-build when the EAS build command already includes --no-wait.');
+    }
     if (!cmd.includes('--json')) {
         cmd += ' --json';
     }
     if (!cmd.includes('--non-interactive')) {
         cmd += ' --non-interactive';
     }
-    if (!cmd.includes('--no-wait')) {
+    if (!waitForBuild) {
         cmd += ' --no-wait';
     }
     try {

--- a/continuous-deploy-fingerprint/README.md
+++ b/continuous-deploy-fingerprint/README.md
@@ -65,6 +65,7 @@ Here is a summary of all the input options you can use.
 | **working-directory**   | -              | The relative directory of your Expo app                                      |
 | **platform**            | `all`          | The platform to deploy on (available options are `ios`, `android` and `all`) |
 | **auto-submit-builds**  | -              | Whether to add the `--auto-submit` flag to the issued `eas build` commands.  |
+| **wait-for-build**      | `false`        | Wait for any newly started EAS Build to complete before the action resolves. |
 | **github-token**        | `github.token` | GitHub token to use when commenting on PR ([read more](#github-tokens))      |
 
 And the action will generate these [outputs](#available-outputs) for other actions to do something based on what this action did.

--- a/continuous-deploy-fingerprint/action.yml
+++ b/continuous-deploy-fingerprint/action.yml
@@ -25,6 +25,10 @@ inputs:
   auto-submit-builds:
     description: Automatically submit new builds to their respective app stores using EAS Build `--auto-submit` flag (EAS Submit).
     required: false
+  wait-for-build:
+    description: Wait for any newly started EAS Build to complete before this action resolves.
+    required: false
+    default: false
   github-token:
     description: GitHub token to use when commenting on PR
     required: false

--- a/preview-build/README.md
+++ b/preview-build/README.md
@@ -97,6 +97,7 @@ Here is a summary of all the input options you can use.
 | **fingerprint-installation-cache** | `true`                                         | If the `@expo/fingerprint` should be cached to speed up installation                           |
 | **fingerprint-db-cache-key**       | `fingerprint-db`                               | A cache key to use for saving the fingerprint database                                         |
 | **eas-build-message**              | Will retrieve from the Git branch HEAD message | A short message describing the build that will pass to `eas build --message`                   |
+| **wait-for-build**                 | `false`                                        | Wait for newly started EAS Builds to complete before the action resolves                       |
 
 ### Available outputs
 

--- a/preview-build/action.yml
+++ b/preview-build/action.yml
@@ -42,6 +42,10 @@ inputs:
     default: fingerprint-db
   eas-build-message:
     description: A short message describing the build
+  wait-for-build:
+    description: Wait for newly started EAS Builds to complete before this action resolves
+    required: false
+    default: false
   previous-git-commit:
     description: The Git hash for the base commit
     required: false

--- a/src/__tests__/expo.test.ts
+++ b/src/__tests__/expo.test.ts
@@ -2,7 +2,14 @@ import * as core from '@actions/core';
 import * as exec from '@actions/exec';
 import * as io from '@actions/io';
 
-import { authenticate, parseCommand, projectDeepLink, projectLink, projectQR } from '../expo';
+import {
+  authenticate,
+  createEasBuildFromRawCommandAsync,
+  parseCommand,
+  projectDeepLink,
+  projectLink,
+  projectQR,
+} from '../expo';
 
 jest.mock('@actions/core');
 jest.mock('@actions/exec');
@@ -48,6 +55,53 @@ describe(authenticate, () => {
     expect(exec.exec).toBeCalledWith('eas', ['whoami'], {
       env: expect.objectContaining({ EXPO_TOKEN: 'faketoken' }),
     });
+  });
+});
+
+describe(createEasBuildFromRawCommandAsync, () => {
+  const buildJson = '[{"id":"build-id","platform":"IOS"}]';
+
+  beforeEach(() => {
+    jest.mocked(io.which).mockResolvedValue('eas');
+    jest.mocked(exec.getExecOutput).mockResolvedValue({
+      stdout: buildJson,
+      stderr: '',
+      exitCode: 0,
+    });
+  });
+
+  it('adds --no-wait by default', async () => {
+    await createEasBuildFromRawCommandAsync('/tmp/project', 'build --platform ios');
+
+    expect(exec.getExecOutput).toHaveBeenCalledWith(
+      'eas build --platform ios --json --non-interactive --no-wait',
+      [],
+      { cwd: '/tmp/project' }
+    );
+  });
+
+  it('omits --no-wait when waitForBuild is enabled', async () => {
+    await createEasBuildFromRawCommandAsync('/tmp/project', 'build --platform ios', [], {
+      waitForBuild: true,
+    });
+
+    expect(exec.getExecOutput).toHaveBeenCalledWith(
+      'eas build --platform ios --json --non-interactive',
+      [],
+      { cwd: '/tmp/project' }
+    );
+  });
+
+  it('rejects conflicting --no-wait when waitForBuild is enabled', async () => {
+    await expect(
+      createEasBuildFromRawCommandAsync('/tmp/project', 'build --platform ios --no-wait', [], {
+        waitForBuild: true,
+      })
+    ).rejects.toThrow(
+      'Cannot use wait-for-build when the EAS build command already includes --no-wait.'
+    );
+
+    expect(exec.getExecOutput).not.toHaveBeenCalled();
   });
 });
 

--- a/src/actions/continuous-deploy-fingerprint.ts
+++ b/src/actions/continuous-deploy-fingerprint.ts
@@ -1,11 +1,17 @@
-import { info, isDebug, setFailed, setOutput } from '@actions/core';
+import { getBooleanInput, info, isDebug, setFailed, setOutput } from '@actions/core';
 import { getExecOutput } from '@actions/exec';
 import { which } from '@actions/io';
 import { ExpoConfig } from '@expo/config';
 
 import { createDetails, getQrTarget, getSchemesInOrderFromConfig } from '../comment';
 import { EasUpdate, getUpdateGroupQr, getUpdateGroupWebsite } from '../eas';
-import { AppPlatform, BuildInfo, appPlatformEmojis, getBuildLogsUrl } from '../expo';
+import {
+  AppPlatform,
+  BuildInfo,
+  appPlatformEmojis,
+  getBuildLogsUrl,
+  getEasBuildWaitArgs,
+} from '../expo';
 import { getBuildInfoForCurrentFingerprintAsync } from '../fingerprintUtils';
 import { createIssueComment, hasPullContext, pullContext } from '../github';
 import { getInput } from '../input';
@@ -31,6 +37,7 @@ export function collectContinuousDeployFingerprintInput() {
     platform: platformInput,
     environment: getInput('environment'),
     autoSubmitBuilds: getInput('auto-submit-builds') === 'true',
+    waitForBuild: getBooleanInput('wait-for-build'),
     githubToken: getInput('github-token', { required: true }),
     workingDirectory: getInput('working-directory', { required: true }),
   };
@@ -61,6 +68,7 @@ export async function continuousDeployFingerprintAction(
           isInPullRequest,
           environment: input.environment,
           autoSubmitBuild: input.autoSubmitBuilds,
+          waitForBuild: input.waitForBuild,
         })
       : null,
     platformsToRun.has('ios')
@@ -71,6 +79,7 @@ export async function continuousDeployFingerprintAction(
           isInPullRequest,
           environment: input.environment,
           autoSubmitBuild: input.autoSubmitBuilds,
+          waitForBuild: input.waitForBuild,
         })
       : null,
   ]);
@@ -124,6 +133,7 @@ async function buildForPlatformIfNecessaryAsync({
   isInPullRequest,
   environment,
   autoSubmitBuild,
+  waitForBuild,
 }: {
   platform: 'ios' | 'android';
   profile: string;
@@ -131,6 +141,7 @@ async function buildForPlatformIfNecessaryAsync({
   isInPullRequest: boolean;
   environment: string | null;
   autoSubmitBuild: boolean;
+  waitForBuild: boolean;
 }): Promise<BuildRunInfo> {
   const humanReadablePlatformName = platform === 'ios' ? 'iOS' : 'Android';
 
@@ -161,6 +172,7 @@ async function buildForPlatformIfNecessaryAsync({
         platform,
         profile,
         autoSubmit: autoSubmitBuild,
+        waitForBuild,
       }),
       isNew: true,
       fingerprintHash,
@@ -173,11 +185,13 @@ async function createEASBuildAsync({
   profile,
   platform,
   autoSubmit,
+  waitForBuild,
 }: {
   cwd: string;
   profile: string;
   platform: 'ios' | 'android';
   autoSubmit: boolean;
+  waitForBuild: boolean;
 }): Promise<BuildInfo> {
   try {
     const extraDebugArgs = isDebug() ? ['--build-logger-level', 'debug'] : [];
@@ -192,7 +206,7 @@ async function createEASBuildAsync({
         platform,
         '--non-interactive',
         '--json',
-        '--no-wait',
+        ...getEasBuildWaitArgs(waitForBuild),
         ...extraDebugArgs,
         ...extraAutoSubmitArgs,
       ],

--- a/src/actions/preview-build.ts
+++ b/src/actions/preview-build.ts
@@ -45,6 +45,7 @@ export function collectPreviewBuildActionInput() {
     shouldComment: !getInput('comment') || getBooleanInput('comment'),
     commentId: getInput('comment-id') || MESSAGE_ID,
     easBuildMessage: getInput('eas-build-message'),
+    waitForBuild: getBooleanInput('wait-for-build'),
   };
 }
 
@@ -102,7 +103,9 @@ export async function previewAction(input = collectPreviewBuildActionInput()) {
     (await getGitCommandMessageAsync({ token: input.githubToken }, input.currentGitCommitHash));
   const args = ['--message', buildMessage];
   const builds = await group(`Run eas ${command}"`, () =>
-    createEasBuildFromRawCommandAsync(input.workingDirectory, command, args)
+    createEasBuildFromRawCommandAsync(input.workingDirectory, command, args, {
+      waitForBuild: input.waitForBuild,
+    })
   );
 
   await maybeUpdateFingerprintDbAsync({
@@ -248,7 +251,9 @@ function createMessageBodyInBuilding(
   return [
     createCommentForEasMetadata(builds),
     '',
-    `Fingerprint is changed, new EAS Build(s) are now in pipeline.`,
+    input.waitForBuild
+      ? `Fingerprint is changed, new EAS Build(s) completed successfully.`
+      : `Fingerprint is changed, new EAS Build(s) are now in pipeline.`,
     '',
     `Build with commit ${input.currentGitCommitHash}`,
     '',

--- a/src/expo.ts
+++ b/src/expo.ts
@@ -157,24 +157,39 @@ export async function easBuild(cmd: Command): Promise<BuildInfo[]> {
   return JSON.parse(stdout);
 }
 
+export function getEasBuildWaitArgs(waitForBuild: boolean): string[] {
+  return waitForBuild ? [] : ['--no-wait'];
+}
+
+function hasEasBuildNoWaitFlag(command: string): boolean {
+  return /(^|\s)--no-wait(?=\s|$)/.test(command);
+}
+
 /**
  * Create an new EAS build using the user-provided command.
  */
 export async function createEasBuildFromRawCommandAsync(
   cwd: string,
   command: string,
-  extraArgs: string[] = []
+  extraArgs: string[] = [],
+  options?: { waitForBuild?: boolean }
 ): Promise<BuildInfo[]> {
   let stdout = '';
+  const waitForBuild = options?.waitForBuild ?? false;
 
   let cmd = command;
+  if (waitForBuild && hasEasBuildNoWaitFlag(cmd)) {
+    throw new Error(
+      'Cannot use wait-for-build when the EAS build command already includes --no-wait.'
+    );
+  }
   if (!cmd.includes('--json')) {
     cmd += ' --json';
   }
   if (!cmd.includes('--non-interactive')) {
     cmd += ' --non-interactive';
   }
-  if (!cmd.includes('--no-wait')) {
+  if (!waitForBuild) {
     cmd += ' --no-wait';
   }
 


### PR DESCRIPTION
## Summary
- add a `wait-for-build` input to `preview-build` and `continuous-deploy-fingerprint`
- stop forcing `--no-wait` when that input is enabled, including user-provided preview build commands
- update docs, tests, and bundled action outputs

## Verification
- `./node_modules/.bin/jest src/__tests__/expo.test.ts --runInBand --watchman=false`
- `CI=0 node ncc.js`