### PR TITLE
[fingerprint] save db to pushed branch by default

### DIFF
--- a/build/command/index.js
+++ b/build/command/index.js
@@ -32598,6 +32598,7 @@ exports.createReaction = createReaction;
 exports.issueComment = issueComment;
 exports.getGitCommandMessageAsync = getGitCommandMessageAsync;
 exports.getRepoDefaultBranch = getRepoDefaultBranch;
+exports.resolveFingerprintDbSavingBranch = resolveFingerprintDbSavingBranch;
 exports.isPushBranchContext = isPushBranchContext;
 exports.getPullRequestFromGitCommitShaAsync = getPullRequestFromGitCommitShaAsync;
 const github_1 = __nccwpck_require__(3228);
@@ -32719,6 +32720,21 @@ async function getGitCommandMessageAsync(options, gitCommitHash) {
  */
 function getRepoDefaultBranch() {
     return github_1.context.payload?.repository?.default_branch;
+}
+/**
+ * Resolve the branch that should own the fingerprint database cache.
+ *
+ * Explicit inputs always win. Otherwise, push events default to the current
+ * branch so stacked pull requests can restore caches from their base branch.
+ */
+function resolveFingerprintDbSavingBranch(savingDbBranch) {
+    if (savingDbBranch) {
+        return savingDbBranch;
+    }
+    if (github_1.context.eventName === 'push' && github_1.context.ref.startsWith('refs/heads/')) {
+        return github_1.context.ref.replace('refs/heads/', '');
+    }
+    return getRepoDefaultBranch();
 }
 /**
  * True if the current event is a push to the target branch.

--- a/build/continuous-deploy-fingerprint/index.js
+++ b/build/continuous-deploy-fingerprint/index.js
@@ -35277,6 +35277,7 @@ exports.createReaction = createReaction;
 exports.issueComment = issueComment;
 exports.getGitCommandMessageAsync = getGitCommandMessageAsync;
 exports.getRepoDefaultBranch = getRepoDefaultBranch;
+exports.resolveFingerprintDbSavingBranch = resolveFingerprintDbSavingBranch;
 exports.isPushBranchContext = isPushBranchContext;
 exports.getPullRequestFromGitCommitShaAsync = getPullRequestFromGitCommitShaAsync;
 const github_1 = __nccwpck_require__(3228);
@@ -35398,6 +35399,21 @@ async function getGitCommandMessageAsync(options, gitCommitHash) {
  */
 function getRepoDefaultBranch() {
     return github_1.context.payload?.repository?.default_branch;
+}
+/**
+ * Resolve the branch that should own the fingerprint database cache.
+ *
+ * Explicit inputs always win. Otherwise, push events default to the current
+ * branch so stacked pull requests can restore caches from their base branch.
+ */
+function resolveFingerprintDbSavingBranch(savingDbBranch) {
+    if (savingDbBranch) {
+        return savingDbBranch;
+    }
+    if (github_1.context.eventName === 'push' && github_1.context.ref.startsWith('refs/heads/')) {
+        return github_1.context.ref.replace('refs/heads/', '');
+    }
+    return getRepoDefaultBranch();
 }
 /**
  * True if the current event is a push to the target branch.

--- a/build/fingerprint-post/index.js
+++ b/build/fingerprint-post/index.js
@@ -97877,7 +97877,7 @@ const utils_1 = __nccwpck_require__(1798);
 const worker_1 = __nccwpck_require__(5101);
 (0, worker_1.executeAction)(runAction);
 async function runAction(input = (0, fingerprint_1.collectFingerprintActionInput)()) {
-    const targetBranch = input.savingDbBranch ?? (0, github_1.getRepoDefaultBranch)();
+    const targetBranch = (0, github_1.resolveFingerprintDbSavingBranch)(input.savingDbBranch);
     (0, assert_1.default)(targetBranch);
     if (!(0, github_1.isPushBranchContext)(targetBranch)) {
         return;
@@ -98317,6 +98317,7 @@ exports.createReaction = createReaction;
 exports.issueComment = issueComment;
 exports.getGitCommandMessageAsync = getGitCommandMessageAsync;
 exports.getRepoDefaultBranch = getRepoDefaultBranch;
+exports.resolveFingerprintDbSavingBranch = resolveFingerprintDbSavingBranch;
 exports.isPushBranchContext = isPushBranchContext;
 exports.getPullRequestFromGitCommitShaAsync = getPullRequestFromGitCommitShaAsync;
 const github_1 = __nccwpck_require__(3228);
@@ -98438,6 +98439,21 @@ async function getGitCommandMessageAsync(options, gitCommitHash) {
  */
 function getRepoDefaultBranch() {
     return github_1.context.payload?.repository?.default_branch;
+}
+/**
+ * Resolve the branch that should own the fingerprint database cache.
+ *
+ * Explicit inputs always win. Otherwise, push events default to the current
+ * branch so stacked pull requests can restore caches from their base branch.
+ */
+function resolveFingerprintDbSavingBranch(savingDbBranch) {
+    if (savingDbBranch) {
+        return savingDbBranch;
+    }
+    if (github_1.context.eventName === 'push' && github_1.context.ref.startsWith('refs/heads/')) {
+        return github_1.context.ref.replace('refs/heads/', '');
+    }
+    return getRepoDefaultBranch();
 }
 /**
  * True if the current event is a push to the target branch.

--- a/build/fingerprint/index.js
+++ b/build/fingerprint/index.js
@@ -98278,6 +98278,7 @@ exports.createReaction = createReaction;
 exports.issueComment = issueComment;
 exports.getGitCommandMessageAsync = getGitCommandMessageAsync;
 exports.getRepoDefaultBranch = getRepoDefaultBranch;
+exports.resolveFingerprintDbSavingBranch = resolveFingerprintDbSavingBranch;
 exports.isPushBranchContext = isPushBranchContext;
 exports.getPullRequestFromGitCommitShaAsync = getPullRequestFromGitCommitShaAsync;
 const github_1 = __nccwpck_require__(3228);
@@ -98399,6 +98400,21 @@ async function getGitCommandMessageAsync(options, gitCommitHash) {
  */
 function getRepoDefaultBranch() {
     return github_1.context.payload?.repository?.default_branch;
+}
+/**
+ * Resolve the branch that should own the fingerprint database cache.
+ *
+ * Explicit inputs always win. Otherwise, push events default to the current
+ * branch so stacked pull requests can restore caches from their base branch.
+ */
+function resolveFingerprintDbSavingBranch(savingDbBranch) {
+    if (savingDbBranch) {
+        return savingDbBranch;
+    }
+    if (github_1.context.eventName === 'push' && github_1.context.ref.startsWith('refs/heads/')) {
+        return github_1.context.ref.replace('refs/heads/', '');
+    }
+    return getRepoDefaultBranch();
 }
 /**
  * True if the current event is a push to the target branch.

--- a/build/preview-comment/index.js
+++ b/build/preview-comment/index.js
@@ -32542,6 +32542,7 @@ exports.createReaction = createReaction;
 exports.issueComment = issueComment;
 exports.getGitCommandMessageAsync = getGitCommandMessageAsync;
 exports.getRepoDefaultBranch = getRepoDefaultBranch;
+exports.resolveFingerprintDbSavingBranch = resolveFingerprintDbSavingBranch;
 exports.isPushBranchContext = isPushBranchContext;
 exports.getPullRequestFromGitCommitShaAsync = getPullRequestFromGitCommitShaAsync;
 const github_1 = __nccwpck_require__(3228);
@@ -32663,6 +32664,21 @@ async function getGitCommandMessageAsync(options, gitCommitHash) {
  */
 function getRepoDefaultBranch() {
     return github_1.context.payload?.repository?.default_branch;
+}
+/**
+ * Resolve the branch that should own the fingerprint database cache.
+ *
+ * Explicit inputs always win. Otherwise, push events default to the current
+ * branch so stacked pull requests can restore caches from their base branch.
+ */
+function resolveFingerprintDbSavingBranch(savingDbBranch) {
+    if (savingDbBranch) {
+        return savingDbBranch;
+    }
+    if (github_1.context.eventName === 'push' && github_1.context.ref.startsWith('refs/heads/')) {
+        return github_1.context.ref.replace('refs/heads/', '');
+    }
+    return getRepoDefaultBranch();
 }
 /**
  * True if the current event is a push to the target branch.

--- a/build/preview/index.js
+++ b/build/preview/index.js
@@ -35375,6 +35375,7 @@ exports.createReaction = createReaction;
 exports.issueComment = issueComment;
 exports.getGitCommandMessageAsync = getGitCommandMessageAsync;
 exports.getRepoDefaultBranch = getRepoDefaultBranch;
+exports.resolveFingerprintDbSavingBranch = resolveFingerprintDbSavingBranch;
 exports.isPushBranchContext = isPushBranchContext;
 exports.getPullRequestFromGitCommitShaAsync = getPullRequestFromGitCommitShaAsync;
 const github_1 = __nccwpck_require__(3228);
@@ -35496,6 +35497,21 @@ async function getGitCommandMessageAsync(options, gitCommitHash) {
  */
 function getRepoDefaultBranch() {
     return github_1.context.payload?.repository?.default_branch;
+}
+/**
+ * Resolve the branch that should own the fingerprint database cache.
+ *
+ * Explicit inputs always win. Otherwise, push events default to the current
+ * branch so stacked pull requests can restore caches from their base branch.
+ */
+function resolveFingerprintDbSavingBranch(savingDbBranch) {
+    if (savingDbBranch) {
+        return savingDbBranch;
+    }
+    if (github_1.context.eventName === 'push' && github_1.context.ref.startsWith('refs/heads/')) {
+        return github_1.context.ref.replace('refs/heads/', '');
+    }
+    return getRepoDefaultBranch();
 }
 /**
  * True if the current event is a push to the target branch.

--- a/build/setup/index.js
+++ b/build/setup/index.js
@@ -98256,6 +98256,7 @@ exports.createReaction = createReaction;
 exports.issueComment = issueComment;
 exports.getGitCommandMessageAsync = getGitCommandMessageAsync;
 exports.getRepoDefaultBranch = getRepoDefaultBranch;
+exports.resolveFingerprintDbSavingBranch = resolveFingerprintDbSavingBranch;
 exports.isPushBranchContext = isPushBranchContext;
 exports.getPullRequestFromGitCommitShaAsync = getPullRequestFromGitCommitShaAsync;
 const github_1 = __nccwpck_require__(3228);
@@ -98377,6 +98378,21 @@ async function getGitCommandMessageAsync(options, gitCommitHash) {
  */
 function getRepoDefaultBranch() {
     return github_1.context.payload?.repository?.default_branch;
+}
+/**
+ * Resolve the branch that should own the fingerprint database cache.
+ *
+ * Explicit inputs always win. Otherwise, push events default to the current
+ * branch so stacked pull requests can restore caches from their base branch.
+ */
+function resolveFingerprintDbSavingBranch(savingDbBranch) {
+    if (savingDbBranch) {
+        return savingDbBranch;
+    }
+    if (github_1.context.eventName === 'push' && github_1.context.ref.startsWith('refs/heads/')) {
+        return github_1.context.ref.replace('refs/heads/', '');
+    }
+    return getRepoDefaultBranch();
 }
 /**
  * True if the current event is a push to the target branch.

--- a/fingerprint/README.md
+++ b/fingerprint/README.md
@@ -48,7 +48,7 @@ To use this action, add the following code to your workflow:
 ```yaml
 on:
   push:
-    # REQUIRED: push main(default) branch is necessary for this action to update its fingerprint database
+    # REQUIRED: push events are necessary for this action to update its fingerprint database
     branches: [main]
   pull_request:
     types: [opened, synchronize]
@@ -56,7 +56,7 @@ on:
 jobs:
   <JOB_NAME>:
     runs-on: <RUNNER>
-    # REQUIRED: limit concurrency when pushing main(default) branch to prevent conflict for this action to update its fingerprint database
+    # REQUIRED: limit concurrency when pushing a save branch to prevent conflicts while updating the fingerprint database
     concurrency: fingerprint-${{ github.event_name != 'pull_request' && 'main' || github.run_id }}
     permissions:
       # REQUIRED: Allow comments of PRs
@@ -84,7 +84,7 @@ Here is a summary of all the input options you can use.
 | **fingerprint-db-cache-key**       | `fingerprint-db` | A cache key to use for saving the fingerprint database                                      |
 | **previous-git-commit**            | -                | The Git hash for the base commit                                                            |
 | **current-git-commit**             | -                | The Git hash for the current commit                                                         |
-| **saving-db-branch**               | -                | The branch for saving the fingerprint database. Defaults to the repository's default branch |
+| **saving-db-branch**               | -                | The branch for saving the fingerprint database. Defaults to the current branch on push events, otherwise the repository's default branch |
 
 And the action will generate these [outputs](#available-outputs) for other actions to do something based on current project fingerprint
 
@@ -109,7 +109,7 @@ name: PR Labeler
 
 on:
   push:
-    # REQUIRED: push main(default) branch is necessary for this action to update its fingerprint database
+    # REQUIRED: push events are necessary for this action to update its fingerprint database
     branches: [main]
   pull_request:
     types: [opened, synchronize]
@@ -117,7 +117,7 @@ on:
 jobs:
   fingerprint:
     runs-on: ubuntu-latest
-    # REQUIRED: limit concurrency when pushing main(default) branch to prevent conflict for this action to update its fingerprint database
+    # REQUIRED: limit concurrency when pushing a save branch to prevent conflicts while updating the fingerprint database
     concurrency: fingerprint-${{ github.event_name != 'pull_request' && 'main' || github.run_id }}
     permissions:
       # REQUIRED: Allow comments of PRs
@@ -194,6 +194,12 @@ jobs:
 This workflow listens for pull request events and generates a fingerprint for each pull request. Based on the `fingerprint-diff` output, the example then use GitHub API to add/remove labels based on fingerprint compatible state.
 
 ## Caveats
+
+### Stacked pull requests
+
+Fingerprint comparisons restore their base commit from the fingerprint database cache. By default, push events now save that database under the pushed branch name, which allows a pull request targeting `feature-a` to restore entries created from pushes to `feature-a`.
+
+If you use stacked pull requests, make sure the workflow also runs on pushes for any branch that may act as a pull request base. In simple workflows that only open pull requests against `main`, pushing `main` is sufficient. If needed, you can still override the save branch explicitly with `saving-db-branch`.
 
 ### GitHub tokens
 

--- a/fingerprint/action.yml
+++ b/fingerprint/action.yml
@@ -40,7 +40,7 @@ inputs:
     description: The Git hash for the current commit
     required: false
   saving-db-branch:
-    description: The branch for saving the fingerprint database. Defaults to the repository's default branch
+    description: The branch for saving the fingerprint database. Defaults to the current branch on push events, otherwise the repository's default branch
     required: false
 
 outputs:

--- a/preview-build/README.md
+++ b/preview-build/README.md
@@ -48,7 +48,7 @@ To use this action, add the following code to your workflow:
 ```yaml
 on:
   push:
-    # REQUIRED: push main(default) branch is necessary for this action to update its fingerprint database
+    # REQUIRED: push events are necessary for this action to update its fingerprint database
     branches: [main]
   pull_request:
     types: [opened, synchronize]
@@ -56,7 +56,7 @@ on:
 jobs:
   <JOB_NAME>:
     runs-on: <RUNNER>
-    # REQUIRED: limit concurrency when pushing main(default) branch to prevent conflict for this action to update its fingerprint database
+    # REQUIRED: limit concurrency when pushing a save branch to prevent conflicts while updating the fingerprint database
     concurrency: fingerprint-${{ github.event_name != 'pull_request' && 'main' || github.run_id }}
     permissions:
       # REQUIRED: Allow comments of PRs
@@ -96,6 +96,7 @@ Here is a summary of all the input options you can use.
 | **fingerprint-version**            | `latest`                                       | `@expo/fingerprint` version to install                                                         |
 | **fingerprint-installation-cache** | `true`                                         | If the `@expo/fingerprint` should be cached to speed up installation                           |
 | **fingerprint-db-cache-key**       | `fingerprint-db`                               | A cache key to use for saving the fingerprint database                                         |
+| **saving-db-branch**               | -                                              | The branch for saving the fingerprint database. Defaults to the current branch on push events, otherwise the repository's default branch |
 | **eas-build-message**              | Will retrieve from the Git branch HEAD message | A short message describing the build that will pass to `eas build --message`                   |
 
 ### Available outputs
@@ -124,7 +125,7 @@ name: Build preview for pull requests
 
 on:
   push:
-    # REQUIRED: push main(default) branch is necessary for this action to update its fingerprint database
+    # REQUIRED: push events are necessary for this action to update its fingerprint database
     branches: [main]
   pull_request:
     types: [opened, synchronize]
@@ -132,7 +133,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # REQUIRED: limit concurrency when pushing main(default) branch to prevent conflict for this action to update its fingerprint database
+    # REQUIRED: limit concurrency when pushing a save branch to prevent conflicts while updating the fingerprint database
     concurrency: fingerprint-${{ github.event_name != 'pull_request' && 'main' || github.run_id }}
     permissions:
       # REQUIRED: Allow comments of PRs
@@ -164,6 +165,12 @@ jobs:
 This workflow listens for pull request events and generates a fingerprint for each pull request. It then uses this action to create an EAS Build for the pull request, and deploys the build using another action.
 
 ## Caveats
+
+### Stacked pull requests
+
+`preview-build` restores its base commit from the fingerprint database cache before deciding whether it can reuse an existing build. By default, push events now save that database under the pushed branch name, which allows a pull request targeting `feature-a` to restore entries created from pushes to `feature-a`.
+
+If you use stacked pull requests, make sure the workflow also runs on pushes for any branch that may act as a pull request base. In simple workflows that only open pull requests against `main`, pushing `main` is sufficient. If needed, you can still override the save branch explicitly with `saving-db-branch`.
 
 ### Preventing duplicate comments
 

--- a/preview-build/action.yml
+++ b/preview-build/action.yml
@@ -49,7 +49,7 @@ inputs:
     description: The Git hash for the current commit
     required: false
   saving-db-branch:
-    description: The branch for saving the fingerprint database. Defaults to the repository's default branch
+    description: The branch for saving the fingerprint database. Defaults to the current branch on push events, otherwise the repository's default branch
     required: false
 
 outputs:

--- a/src/__tests__/actions/fingerprint-post.test.ts
+++ b/src/__tests__/actions/fingerprint-post.test.ts
@@ -1,0 +1,59 @@
+import * as cacher from '../../cacher';
+import * as fingerprint from '../../fingerprint';
+import * as github from '../../github';
+import * as utils from '../../utils';
+import { runAction } from '../../actions/fingerprint-post';
+
+jest.mock('../../cacher');
+jest.mock('../../fingerprint');
+jest.mock('../../github');
+jest.mock('../../utils');
+jest.mock('../../worker', () => ({
+  executeAction: jest.fn(),
+}));
+
+describe(runAction, () => {
+  beforeEach(() => {
+    process.env.GITHUB_REF = 'refs/heads/feature-a';
+    jest.mocked(utils.retryAsync).mockImplementation(async action => await action());
+  });
+
+  afterEach(() => {
+    delete process.env.GITHUB_REF;
+    jest.resetAllMocks();
+  });
+
+  it('saves the fingerprint db on the resolved push branch', async () => {
+    jest.mocked(github.resolveFingerprintDbSavingBranch).mockReturnValue('feature-a');
+    jest.mocked(github.isPushBranchContext).mockReturnValue(true);
+
+    await runAction({
+      fingerprintDbCacheKey: 'fingerprint-db',
+      githubToken: 'github-token',
+      savingDbBranch: undefined,
+    } as any);
+
+    expect(github.resolveFingerprintDbSavingBranch).toHaveBeenCalledWith(undefined);
+    expect(github.isPushBranchContext).toHaveBeenCalledWith('feature-a');
+    expect(cacher.deleteCacheAsync).toHaveBeenCalledWith(
+      'github-token',
+      'fingerprint-db',
+      'refs/heads/feature-a'
+    );
+    expect(fingerprint.saveDbToCacheAsync).toHaveBeenCalledWith('fingerprint-db');
+  });
+
+  it('skips saving when the event is not a push to the resolved branch', async () => {
+    jest.mocked(github.resolveFingerprintDbSavingBranch).mockReturnValue('feature-a');
+    jest.mocked(github.isPushBranchContext).mockReturnValue(false);
+
+    await runAction({
+      fingerprintDbCacheKey: 'fingerprint-db',
+      githubToken: 'github-token',
+      savingDbBranch: undefined,
+    } as any);
+
+    expect(cacher.deleteCacheAsync).not.toHaveBeenCalled();
+    expect(fingerprint.saveDbToCacheAsync).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/actions/preview-build.test.ts
+++ b/src/__tests__/actions/preview-build.test.ts
@@ -1,0 +1,98 @@
+import * as cacher from '../../cacher';
+import * as core from '@actions/core';
+
+import * as expo from '../../expo';
+import * as fingerprint from '../../fingerprint';
+import * as github from '../../github';
+import * as project from '../../project';
+import * as utils from '../../utils';
+import { previewAction } from '../../actions/preview-build';
+
+jest.mock('@actions/core');
+jest.mock('../../cacher');
+jest.mock('../../expo');
+jest.mock('../../fingerprint');
+jest.mock('../../github');
+jest.mock('../../project');
+jest.mock('../../utils');
+jest.mock('../../worker', () => ({
+  executeAction: jest.fn(),
+}));
+
+describe(previewAction, () => {
+  const dbManager = {
+    upsertFingerprintByGitCommitHashAsync: jest.fn(),
+    getLatestEasEntityFromFingerprintAsync: jest.fn(),
+  };
+
+  const input = {
+    command: 'eas build --platform all',
+    commentId: 'comment-id',
+    currentGitCommitHash: 'head-sha',
+    easBuildMessage: '',
+    fingerprintDbCacheKey: 'fingerprint-db',
+    fingerprintInstallationCache: true,
+    fingerprintVersion: 'latest',
+    githubToken: 'github-token',
+    packager: 'yarn',
+    previousGitCommitHash: 'base-sha',
+    savingDbBranch: undefined,
+    shouldComment: false,
+    workingDirectory: '/tmp/app',
+  };
+
+  beforeEach(() => {
+    process.env.GITHUB_REF = 'refs/heads/feature-a';
+    jest.mocked(core.group).mockImplementation((_, action) => action());
+    jest.mocked(utils.retryAsync).mockImplementation(async action => await action());
+    jest.mocked(project.loadProjectConfig).mockResolvedValue({
+      extra: { eas: { projectId: 'project-id' } },
+    } as any);
+    jest.mocked(github.hasPullContext).mockReturnValue(false);
+    jest.mocked(github.resolveFingerprintDbSavingBranch).mockReturnValue('feature-a');
+    jest.mocked(github.isPushBranchContext).mockReturnValue(true);
+    jest.mocked(github.getPullRequestFromGitCommitShaAsync).mockResolvedValue([]);
+    jest.mocked(fingerprint.createFingerprintDbManagerAsync).mockResolvedValue(dbManager as any);
+    jest.mocked(fingerprint.createFingerprintOutputAsync).mockResolvedValue({
+      currentFingerprint: { hash: 'hash', sources: [] },
+      previousFingerprint: null,
+      diff: [],
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.GITHUB_REF;
+    jest.resetAllMocks();
+    dbManager.upsertFingerprintByGitCommitHashAsync.mockReset();
+    dbManager.getLatestEasEntityFromFingerprintAsync.mockReset();
+  });
+
+  it('updates the fingerprint db on pushes to the resolved branch', async () => {
+    await previewAction(input as any);
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(github.resolveFingerprintDbSavingBranch).toHaveBeenCalledWith(undefined);
+    expect(github.isPushBranchContext).toHaveBeenCalledWith('feature-a');
+    expect(dbManager.upsertFingerprintByGitCommitHashAsync).toHaveBeenCalledWith('head-sha', {
+      fingerprint: { hash: 'hash', sources: [] },
+    });
+    expect(cacher.deleteCacheAsync).toHaveBeenCalledWith(
+      'github-token',
+      'fingerprint-db',
+      'refs/heads/feature-a'
+    );
+    expect(fingerprint.saveDbToCacheAsync).toHaveBeenCalledWith('fingerprint-db');
+  });
+
+  it('skips db updates when the event is not a push to the resolved branch', async () => {
+    jest.mocked(github.isPushBranchContext).mockReturnValue(false);
+
+    await previewAction(input as any);
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(fingerprint.createFingerprintDbManagerAsync).not.toHaveBeenCalled();
+    expect(cacher.deleteCacheAsync).not.toHaveBeenCalled();
+    expect(fingerprint.saveDbToCacheAsync).not.toHaveBeenCalled();
+    expect(expo.queryEasBuildInfoAsync).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/github.test.ts
+++ b/src/__tests__/github.test.ts
@@ -1,7 +1,12 @@
 import * as github from '@actions/github';
 
 import { resetEnv, setEnv } from './utils';
-import { githubApi, pullContext } from '../github';
+import {
+  githubApi,
+  isPushBranchContext,
+  pullContext,
+  resolveFingerprintDbSavingBranch,
+} from '../github';
 
 jest.mock('@actions/github');
 
@@ -48,5 +53,40 @@ describe(pullContext, () => {
     jest.mocked(github.context).eventName = 'pull_request';
     jest.mocked(github.context).issue = { owner: 'fakeowner', repo: 'fakerepo', number: 1337 };
     expect(pullContext()).toMatchObject({ owner: 'fakeowner', repo: 'fakerepo', number: 1337 });
+  });
+});
+
+describe(resolveFingerprintDbSavingBranch, () => {
+  afterEach(() => {
+    jest.mocked(github.context).eventName = undefined as any;
+    jest.mocked(github.context).ref = undefined as any;
+    jest.mocked(github.context).payload = {};
+  });
+
+  it('prefers explicit saving-db-branch input', () => {
+    jest.mocked(github.context).eventName = 'push';
+    jest.mocked(github.context).ref = 'refs/heads/current-branch';
+    expect(resolveFingerprintDbSavingBranch('configured-branch')).toBe('configured-branch');
+  });
+
+  it('defaults to the current push branch', () => {
+    jest.mocked(github.context).eventName = 'push';
+    jest.mocked(github.context).ref = 'refs/heads/feature-a';
+    expect(resolveFingerprintDbSavingBranch()).toBe('feature-a');
+  });
+
+  it('falls back to the repository default branch outside push events', () => {
+    jest.mocked(github.context).eventName = 'pull_request';
+    jest.mocked(github.context).payload = { repository: { default_branch: 'main' } } as any;
+    expect(resolveFingerprintDbSavingBranch()).toBe('main');
+  });
+});
+
+describe(isPushBranchContext, () => {
+  it('matches the current push branch ref', () => {
+    jest.mocked(github.context).eventName = 'push';
+    jest.mocked(github.context).ref = 'refs/heads/feature-a';
+    expect(isPushBranchContext('feature-a')).toBe(true);
+    expect(isPushBranchContext('main')).toBe(false);
   });
 });

--- a/src/actions/fingerprint-post.ts
+++ b/src/actions/fingerprint-post.ts
@@ -3,14 +3,14 @@ import assert from 'assert';
 
 import { deleteCacheAsync } from '../cacher';
 import { collectFingerprintActionInput, saveDbToCacheAsync } from '../fingerprint';
-import { getRepoDefaultBranch, isPushBranchContext } from '../github';
+import { isPushBranchContext, resolveFingerprintDbSavingBranch } from '../github';
 import { retryAsync } from '../utils';
 import { executeAction } from '../worker';
 
 executeAction(runAction);
 
 export async function runAction(input = collectFingerprintActionInput()) {
-  const targetBranch = input.savingDbBranch ?? getRepoDefaultBranch();
+  const targetBranch = resolveFingerprintDbSavingBranch(input.savingDbBranch);
   assert(targetBranch);
   if (!isPushBranchContext(targetBranch)) {
     return;

--- a/src/actions/preview-build.ts
+++ b/src/actions/preview-build.ts
@@ -27,10 +27,10 @@ import {
   fetchIssueComment,
   getGitCommandMessageAsync,
   getPullRequestFromGitCommitShaAsync,
-  getRepoDefaultBranch,
   hasPullContext,
   isPushBranchContext,
   pullContext,
+  resolveFingerprintDbSavingBranch,
 } from '../github';
 import { loadProjectConfig } from '../project';
 import { retryAsync, template } from '../utils';
@@ -318,7 +318,7 @@ async function maybeUpdateFingerprintDbAsync(params: {
     fingerprint: Fingerprint;
   }[];
 }) {
-  const targetBranch = params.savingDbBranch ?? getRepoDefaultBranch();
+  const targetBranch = resolveFingerprintDbSavingBranch(params.savingDbBranch);
   assert(targetBranch);
   if (!isPushBranchContext(targetBranch)) {
     return;
@@ -347,7 +347,7 @@ async function handleNonPullRequest(
   input: ReturnType<typeof collectPreviewBuildActionInput>
 ) {
   info('Non pull request context, skipping comment.');
-  const targetBranch = input.savingDbBranch ?? getRepoDefaultBranch();
+  const targetBranch = resolveFingerprintDbSavingBranch(input.savingDbBranch);
   assert(targetBranch);
   if (!isPushBranchContext(targetBranch)) {
     return;

--- a/src/github.ts
+++ b/src/github.ts
@@ -168,6 +168,24 @@ export function getRepoDefaultBranch(): string | undefined {
 }
 
 /**
+ * Resolve the branch that should own the fingerprint database cache.
+ *
+ * Explicit inputs always win. Otherwise, push events default to the current
+ * branch so stacked pull requests can restore caches from their base branch.
+ */
+export function resolveFingerprintDbSavingBranch(
+  savingDbBranch?: string
+): string | undefined {
+  if (savingDbBranch) {
+    return savingDbBranch;
+  }
+  if (context.eventName === 'push' && context.ref.startsWith('refs/heads/')) {
+    return context.ref.replace('refs/heads/', '');
+  }
+  return getRepoDefaultBranch();
+}
+
+/**
  * True if the current event is a push to the target branch.
  *
  * @param targetBranch The branch to compare against.


### PR DESCRIPTION
# Why

Fixes #339.

Fingerprint DB entries were only saved to the repository default branch by default. That breaks stacked pull requests because a PR targeting `feature-a` can only restore caches from `feature-a` or the default branch, so entries created from pushes to `feature-a` were missing unless users explicitly configured `saving-db-branch`.

# How

- resolve the default fingerprint DB save branch to the current branch on push events
- keep explicit `saving-db-branch` as the highest-priority override
- apply the same behavior to both `fingerprint` and `preview-build`
- add tests for the shared branch resolver and both save paths
- document the new default behavior and the stacked-branch workflow requirement

# Test Plan

- `pnpm exec jest --runInBand --watchman=false --forceExit`
- `node ncc.js`