### PR TITLE
chore!: update tooling and actions to Node 24

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -8,7 +8,7 @@ inputs:
 
   node-version:
     description: Version of Node to use
-    default: 20.x
+    default: 24.x
 
 runs:
   using: composite

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   icon: terminal
   color: gray-dark
 runs:
-  using: node20
+  using: node24
   main: build/setup/index.js
 inputs:
   expo-version:

--- a/build/command/index.js
+++ b/build/command/index.js
@@ -32500,12 +32500,12 @@ async function queryEasBuildInfoAsync(cwd, buildId) {
     return null;
 }
 /**
- * Try to resolve the project info, by running 'expo config --type prebuild'.
+ * Try to resolve the project info using the app's own Expo CLI.
  */
 async function projectInfo(dir) {
     let stdout = '';
     try {
-        ({ stdout } = await (0, exec_1.getExecOutput)(await (0, io_1.which)('expo', true), ['config', '--json', '--type', 'prebuild'], {
+        ({ stdout } = await (0, exec_1.getExecOutput)('npx', ['expo', 'config', '--json', '--type', 'prebuild'], {
             cwd: dir,
             silent: true,
         }));

--- a/build/continuous-deploy-fingerprint-info/index.js
+++ b/build/continuous-deploy-fingerprint-info/index.js
@@ -28104,12 +28104,12 @@ async function queryEasBuildInfoAsync(cwd, buildId) {
     return null;
 }
 /**
- * Try to resolve the project info, by running 'expo config --type prebuild'.
+ * Try to resolve the project info using the app's own Expo CLI.
  */
 async function projectInfo(dir) {
     let stdout = '';
     try {
-        ({ stdout } = await (0, exec_1.getExecOutput)(await (0, io_1.which)('expo', true), ['config', '--json', '--type', 'prebuild'], {
+        ({ stdout } = await (0, exec_1.getExecOutput)('npx', ['expo', 'config', '--json', '--type', 'prebuild'], {
             cwd: dir,
             silent: true,
         }));

--- a/build/continuous-deploy-fingerprint/index.js
+++ b/build/continuous-deploy-fingerprint/index.js
@@ -35065,12 +35065,12 @@ async function queryEasBuildInfoAsync(cwd, buildId) {
     return null;
 }
 /**
- * Try to resolve the project info, by running 'expo config --type prebuild'.
+ * Try to resolve the project info using the app's own Expo CLI.
  */
 async function projectInfo(dir) {
     let stdout = '';
     try {
-        ({ stdout } = await (0, exec_1.getExecOutput)(await (0, io_1.which)('expo', true), ['config', '--json', '--type', 'prebuild'], {
+        ({ stdout } = await (0, exec_1.getExecOutput)('npx', ['expo', 'config', '--json', '--type', 'prebuild'], {
             cwd: dir,
             silent: true,
         }));

--- a/build/preview-comment/index.js
+++ b/build/preview-comment/index.js
@@ -32444,12 +32444,12 @@ async function queryEasBuildInfoAsync(cwd, buildId) {
     return null;
 }
 /**
- * Try to resolve the project info, by running 'expo config --type prebuild'.
+ * Try to resolve the project info using the app's own Expo CLI.
  */
 async function projectInfo(dir) {
     let stdout = '';
     try {
-        ({ stdout } = await (0, exec_1.getExecOutput)(await (0, io_1.which)('expo', true), ['config', '--json', '--type', 'prebuild'], {
+        ({ stdout } = await (0, exec_1.getExecOutput)('npx', ['expo', 'config', '--json', '--type', 'prebuild'], {
             cwd: dir,
             silent: true,
         }));

--- a/build/preview/index.js
+++ b/build/preview/index.js
@@ -35277,12 +35277,12 @@ async function queryEasBuildInfoAsync(cwd, buildId) {
     return null;
 }
 /**
- * Try to resolve the project info, by running 'expo config --type prebuild'.
+ * Try to resolve the project info using the app's own Expo CLI.
  */
 async function projectInfo(dir) {
     let stdout = '';
     try {
-        ({ stdout } = await (0, exec_1.getExecOutput)(await (0, io_1.which)('expo', true), ['config', '--json', '--type', 'prebuild'], {
+        ({ stdout } = await (0, exec_1.getExecOutput)('npx', ['expo', 'config', '--json', '--type', 'prebuild'], {
             cwd: dir,
             silent: true,
         }));

--- a/build/setup/index.js
+++ b/build/setup/index.js
@@ -98158,12 +98158,12 @@ async function queryEasBuildInfoAsync(cwd, buildId) {
     return null;
 }
 /**
- * Try to resolve the project info, by running 'expo config --type prebuild'.
+ * Try to resolve the project info using the app's own Expo CLI.
  */
 async function projectInfo(dir) {
     let stdout = '';
     try {
-        ({ stdout } = await (0, exec_1.getExecOutput)(await (0, io_1.which)('expo', true), ['config', '--json', '--type', 'prebuild'], {
+        ({ stdout } = await (0, exec_1.getExecOutput)('npx', ['expo', 'config', '--json', '--type', 'prebuild'], {
             cwd: dir,
             silent: true,
         }));

--- a/command/action.yml
+++ b/command/action.yml
@@ -6,7 +6,7 @@ branding:
   icon: message-circle
   color: gray-dark
 runs:
-  using: node20
+  using: node24
   main: ../build/command/index.js
 inputs:
   github-token:

--- a/continuous-deploy-fingerprint-info/action.yml
+++ b/continuous-deploy-fingerprint-info/action.yml
@@ -6,7 +6,7 @@ branding:
   icon: smartphone
   color: gray-dark
 runs:
-  using: node20
+  using: node24
   main: ../build/continuous-deploy-fingerprint-info/index.js
 inputs:
   profile:

--- a/continuous-deploy-fingerprint/action.yml
+++ b/continuous-deploy-fingerprint/action.yml
@@ -6,7 +6,7 @@ branding:
   icon: smartphone
   color: gray-dark
 runs:
-  using: node20
+  using: node24
   main: ../build/continuous-deploy-fingerprint/index.js
 inputs:
   profile:

--- a/fingerprint/action.yml
+++ b/fingerprint/action.yml
@@ -6,7 +6,7 @@ branding:
   icon: smartphone
   color: gray-dark
 runs:
-  using: node20
+  using: node24
   main: ../build/fingerprint/index.js
   post: ../build/fingerprint-post/index.js
   post-if: success()

--- a/package.json
+++ b/package.json
@@ -37,15 +37,15 @@
     "@semantic-release/changelog": "^6.0.2",
     "@semantic-release/exec": "^7.0.3",
     "@semantic-release/git": "^10.0.1",
-    "@tsconfig/node20": "^20.1.4",
+    "@tsconfig/node24": "^24.0.4",
     "@types/jest": "^29.5.14",
-    "@types/node": "^22.13.4",
+    "@types/node": "^24.12.3",
     "@types/semver": "^7.5.8",
     "@types/uuid": "^10.0.0",
     "@vercel/ncc": "^0.38.3",
     "conventional-changelog-conventionalcommits": "^8.0.0",
     "eslint": "^8.57.1",
-    "eslint-config-universe": "^14.0.0",
+    "eslint-config-universe": "^15.2.0",
     "getenv": "^1.0.0",
     "jest": "^29.3.1",
     "jest-snapshot-prettier": "npm:prettier@^2.8.8",
@@ -53,7 +53,7 @@
     "semantic-release": "^24.2.2",
     "sqlite3": "^5.1.6",
     "ts-jest": "^29.2.5",
-    "typescript": "^5.7.3"
+    "typescript": "^5.9.3"
   },
   "trustedDependencies": [
     "sqlite3"

--- a/preview-build/action.yml
+++ b/preview-build/action.yml
@@ -6,7 +6,7 @@ branding:
   icon: smartphone
   color: gray-dark
 runs:
-  using: node20
+  using: node24
   main: ../build/preview-build/index.js
 inputs:
   command:

--- a/preview-comment/action.yml
+++ b/preview-comment/action.yml
@@ -6,7 +6,7 @@ branding:
   icon: message-circle
   color: gray-dark
 runs:
-  using: node20
+  using: node24
   main: ../build/preview-comment/index.js
 inputs:
   project:

--- a/preview/action.yml
+++ b/preview/action.yml
@@ -6,7 +6,7 @@ branding:
   icon: smartphone
   color: gray-dark
 runs:
-  using: node20
+  using: node24
   main: ../build/preview/index.js
 inputs:
   command:

--- a/src/__tests__/expo.test.ts
+++ b/src/__tests__/expo.test.ts
@@ -2,7 +2,14 @@ import * as core from '@actions/core';
 import * as exec from '@actions/exec';
 import * as io from '@actions/io';
 
-import { authenticate, parseCommand, projectDeepLink, projectLink, projectQR } from '../expo';
+import {
+  authenticate,
+  parseCommand,
+  projectDeepLink,
+  projectInfo,
+  projectLink,
+  projectQR,
+} from '../expo';
 
 jest.mock('@actions/core');
 jest.mock('@actions/exec');
@@ -48,6 +55,28 @@ describe(authenticate, () => {
     expect(exec.exec).toBeCalledWith('eas', ['whoami'], {
       env: expect.objectContaining({ EXPO_TOKEN: 'faketoken' }),
     });
+  });
+});
+
+describe(projectInfo, () => {
+  it('resolves project info using the project Expo CLI', async () => {
+    jest.mocked(exec.getExecOutput).mockResolvedValue({
+      exitCode: 0,
+      stdout: JSON.stringify({ name: 'fakename', slug: 'fakeslug', owner: 'fakeowner' }),
+      stderr: '',
+    });
+
+    await expect(projectInfo('fake/path')).resolves.toStrictEqual({
+      name: 'fakename',
+      slug: 'fakeslug',
+      owner: 'fakeowner',
+    });
+    expect(exec.getExecOutput).toBeCalledWith(
+      'npx',
+      ['expo', 'config', '--json', '--type', 'prebuild'],
+      { cwd: 'fake/path', silent: true }
+    );
+    expect(io.which).not.toBeCalledWith('expo', true);
   });
 });
 

--- a/src/expo.ts
+++ b/src/expo.ts
@@ -224,20 +224,16 @@ export async function queryEasBuildInfoAsync(
 }
 
 /**
- * Try to resolve the project info, by running 'expo config --type prebuild'.
+ * Try to resolve the project info using the app's own Expo CLI.
  */
 export async function projectInfo(dir: string): Promise<ProjectInfo> {
   let stdout = '';
 
   try {
-    ({ stdout } = await getExecOutput(
-      await which('expo', true),
-      ['config', '--json', '--type', 'prebuild'],
-      {
-        cwd: dir,
-        silent: true,
-      }
-    ));
+    ({ stdout } = await getExecOutput('npx', ['expo', 'config', '--json', '--type', 'prebuild'], {
+      cwd: dir,
+      silent: true,
+    }));
   } catch (error: unknown) {
     throw new Error(`Could not fetch the project info from ${dir}`, { cause: error });
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node20",
+  "extends": "@tsconfig/node24",
   "compilerOptions": {
     "strict": true,
     "noEmit": true,


### PR DESCRIPTION
### Linked issue
Fixes #351

### Additional context
Updates all JavaScript action manifests to run with `node24`, matching GitHub Actions metadata support and the Node 20 deprecation guidance for action maintainers.

Also updates project info resolution to use the app's project-local Expo CLI via `npx expo config`, avoiding the legacy global `expo-cli` path that failed against the generated SDK 56 preview-comment test app.

### Validation:
CI should pass